### PR TITLE
feat(video-subtitle): ffmpeg-Whisper subtitle & filler-cut pipeline

### DIFF
--- a/.claude/skills/video-subtitle/SKILL.md
+++ b/.claude/skills/video-subtitle/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: video-subtitle
+description: End-to-end video subtitle and edit pipeline that replaces the Premiere round-trip — extract audio with two-pass loudness normalisation, transcribe with faster-whisper large-v3 (full precision, word timestamps), clean Whisper hallucinations, proofread the SRT through Claude with a glossary-aware cached prompt, detect and cut filler words and stutters with audio fades, and burn in subtitles at visually-lossless quality. Use when the user asks to generate subtitles, caption a video, cut fillers, or produce a finished mp4 from raw footage.
+---
+
+# video-subtitle
+
+Goal: take raw footage to a finished deliverable in one command, without a single Premiere round-trip and without quietly trading quality for speed.
+
+```
+入力動画
+  └─ ffmpeg: 抽出 (highpass 80Hz)
+       └─ ffmpeg: 2-pass loudnorm (-16 LUFS, linear)            [放送基準]
+            └─ faster-whisper large-v3 (float32, beam 10,        [full precision]
+               condition_on_previous_text, VAD, word timestamps,
+               glossary を initial_prompt に注入)
+                 └─ clean_srt: ループ・幻覚除去
+                      └─ Claude Sonnet 4.6 で校正                [glossary をキャッシュ]
+                         (誤字・固有名詞・カナ漢字・句読点の局所修正のみ)
+                          └─ word timestamps からフィラー/吃り/長無音検出
+                              └─ ffmpeg: 該当区間カット (音声フェード)
+                                  └─ ffmpeg: CRF 17 / preset slow で焼き込み
+```
+
+これを Premiere の従来運用と並べると:
+
+| 旧 (Premiere 運用) | 新 (このパイプライン) |
+|---|---|
+| Premiere で文字起こし | Whisper large-v3 + word timestamps |
+| Premiere の "Filler Word Detection" でカット | word-level filler 辞書 + 吃り検出 (誤判定は `cuts.json` で目視→`--exclude-cut` で除外) |
+| SRT 書き出し | 自動 |
+| Claude にコピペで校正依頼 | パイプラインに組み込み済み (`proofread.py`) |
+| Premiere に SRT 戻す | 不要 (焼き込み版を直接出力) |
+| 誤って切られたフィラーを手戻し | カット前に `cuts.json` レビュー、または再実行で `--exclude-cut` |
+
+## 一発実行
+
+```bash
+scripts/video-subtitle/run.sh path/to/input.mp4
+```
+
+成果物 (入力の隣):
+
+| ファイル | 用途 |
+|---|---|
+| `<name>.raw.wav` / `.wav` | 抽出+整音 (キャッシュ) |
+| `<name>.raw.srt` | Whisper 生出力 (キャッシュ) |
+| `<name>.words.json` | 単語タイミング (cuts 検出用、キャッシュ) |
+| `<name>.clean.srt` | クリーナ通過後 |
+| `<name>.proofread.srt` | Claude 校正後 (キャッシュ) |
+| `<name>.proofread.diff` | 校正前後の unified diff (目視レビュー用) |
+| `<name>.srt` | **最終 SRT** (Premiere に戻す場合これを使う) |
+| `<name>.cuts.json` | カット候補一覧 (start/end/reason/text/context) |
+| `<name>.review.md` | 人間用カット一覧表 |
+| `<name>.cut.mp4` / `.cut.srt` | カット適用後 (タイムスタンプ調整済み) |
+| `<name>.subtitled.mp4` | **完パケ焼き込み** (納品形態) |
+
+中間ファイルは全部キャッシュ。校正/カット/焼き込みを別々にやり直せる。
+
+## オプション
+
+| フラグ | 意味 | 既定 |
+|---|---|---|
+| `--lang <code>` | `ja` / `en` 等 | `ja` |
+| `--model <name>` | `tiny`/`base`/`small`/`medium`/`large-v3` | `large-v3` |
+| `--beam <n>` | beam search 幅 | `10` |
+| `--prompt <text>` | Whisper の `initial_prompt` (glossary に追記される) | (空) |
+| `--glossary <path>` | 用語集ファイル | `scripts/video-subtitle/glossary.txt` |
+| `--no-proofread` | Claude 校正をスキップ (API キー無しでも自動スキップされる) | 実行 |
+| `--no-cut` | フィラー/吃り検出とカットをスキップ | 実行 |
+| `--aggressive-fillers` | `あの` `まあ` `なんか` `ちょっと` も filler 扱い | off |
+| `--silence-threshold <s>` | N 秒以上の無音を ~0.3s まで詰める | off |
+| `--exclude-cut START-END` | 指定範囲をカット対象から除外 (繰り返し可) | — |
+| `--no-burn` | SRT のみ出力。焼き込みなし | 焼き込む |
+| `--no-normalize` | loudnorm をかけない | かける |
+| `--crf <n>` | libx264 CRF (17 = 視覚可逆) | `17` |
+| `--preset <name>` | libx264 preset | `slow` |
+| `--font <name>` | 焼き込みフォント | macOS=Hiragino / それ以外=Noto |
+| `--fontsize <n>` | 0 で動画高さの 4% を自動採用 | `0` |
+| `--preview` | tiny + loudnorm/cut/proofread/burn 全部スキップ。**品質トレードあり、明示的 opt-in** | off |
+
+## カット精度を保つ仕組み
+
+旧運用での一番の苦痛が「Premiere が無音と低信頼度で勝手にフィラー判定して切る」こと。同じことを繰り返さないために:
+
+1. **word-level 判定**。Whisper の `word_timestamps` を使うので「あの人」の「あの」と独立した「あの」を区別できる。
+2. **保守的辞書を既定に**。`えー` `えーと` `あー` `うー` `えっと` だけ。文脈で意味を持つ語 (`あの` `まあ` `なんか` `ちょっと`) は `--aggressive-fillers` で明示的に有効化。
+3. **すべてのカットを `cuts.json` と `review.md` に書き出す**。何が切られたか実行直後に確認できる。
+4. **`--exclude-cut 12.3-13.1` で個別除外**。全工程キャッシュなので、カット判定だけ直して数十秒で再走行できる。
+5. **音声フェード (12ms)** をカット境界に入れて、編集点クリックを物理的に消す。
+6. **吃り検出は 3 回以上の連続反復のみ**。「とても とても」のような正当な強調は残す。
+
+## Claude 校正の中身
+
+- モデル: **`claude-sonnet-4-6`** (Opus は校正タスクには過剰、Sonnet で精度十分かつ速く安い)
+- プロンプト: 校正方針 (固定) + glossary (プロジェクトごと) を `system` に置き、glossary ブロックに `cache_control` 設定。チャンク (40 cue ずつ) は `messages` に毎回入る。
+- **キャッシュ効果**: 1 チャンク目だけ用語集に full price、以降はキャッシュ読み (~0.1×)。glossary が ~2000 トークン超ならキャッシュ。届かない場合は warning が出る。
+- 出力: Pydantic スキーマで構造化 (`{cue_index, original, corrected, reason}`)。タイムスタンプは絶対に触らない、cue を消さない、書き換えない。**局所修正のみ**。
+- ANTHROPIC_API_KEY が無ければ自動スキップして clean.srt をそのまま使う。
+
+## 用語集 (`glossary.txt`)
+
+```
+# Lumenium 関連
+Lumenium
+
+# Stack
+Next.js
+Vercel
+TypeScript
+```
+
+`#` でコメント。1 行 1 語。Whisper の `initial_prompt` と Claude のシステムプロンプト両方に注入される。**追加運用がそのまま品質改善になる**ので、誤認識を見つけたらここに追記して再走行 (Whisper キャッシュは消す)。
+
+## 所要時間 (10 分動画、品質既定)
+
+| 環境 | Whisper (large-v3, beam 10) | Claude 校正 | カット適用 + 焼き込み |
+|---|---|---|---|
+| CPU 8 コア | 30-60 分 | 1-3 分 | 実尺 × 1-2 |
+| CUDA GPU (L4/T4) | 3-8 分 | 1-3 分 | 実尺 × 0.5-1 |
+
+GPU で回すと精度を落とさず速くなる唯一の正攻法。CPU 専用環境なら時間を呑む。
+
+## 推奨ワークフロー
+
+1. 用語集を編集。ありそうな固有名詞を入れておく
+2. `run.sh video.mp4` を流して放置
+3. 完了後、`<name>.review.md` でカット一覧、`<name>.proofread.diff` で校正内容を 1 分でレビュー
+4. 違和感がある箇所だけ `--exclude-cut START-END` または手動で `<name>.srt` を編集して再走行 (Whisper/校正はキャッシュから即終了、カット+焼き込みだけ走る)
+5. `<name>.subtitled.mp4` を納品 / `<name>.srt` を Premiere にインポート
+
+## Claude がやること
+
+ユーザーから動画パスと依頼が来たら:
+
+1. `ffprobe` で長さを確認、所要時間の目安を伝える
+2. 固有名詞や専門用語があれば聞き出して `--prompt` または glossary 追記
+3. ANTHROPIC_API_KEY の有無を確認、ない場合は校正がスキップされることを明言
+4. 既定で `run.sh video.mp4` を実行
+5. 完了後、`review.md` を読み上げて怪しいカットがあれば `--exclude-cut` を提案
+
+`--preview` は **品質を落とすので勝手に使わない** — ユーザーが明示的に頼んだときだけ。
+
+## ファイル構成
+
+```
+scripts/video-subtitle/
+├── run.sh                 # オーケストレーション
+├── bootstrap.sh           # 依存導入 (ffmpeg + faster-whisper + anthropic)
+├── transcribe.py          # faster-whisper ラッパー (words.json も書く)
+├── clean_srt.py           # ループ・ハルシネーション・短尺/長尺整形
+├── proofread.py           # Claude API (Sonnet 4.6 + prompt caching + Pydantic)
+├── detect_fillers.py      # word-level filler/stutter/silence 検出
+├── apply_cuts.py          # ffmpeg concat + audio fade + SRT shift
+├── glossary.txt           # 用語集 (編集して使う)
+└── tests/
+    ├── test_clean_srt.py     (20 cases)
+    ├── test_detect_fillers.py (12 cases)
+    └── test_apply_cuts.py     (12 cases)
+```
+
+`python3 -m unittest` で全 44 ケース走る。外部依存なし。

--- a/scripts/video-subtitle/apply_cuts.py
+++ b/scripts/video-subtitle/apply_cuts.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Apply cuts.json to a video + SRT.
+
+Outputs:
+  - <base>.cut.mp4 — video with cut ranges removed, audio re-encoded with
+    short fades at boundaries to prevent clicks
+  - <base>.cut.srt — SRT with timestamps shifted to match the cut video,
+    cues fully inside cuts dropped, partially-overlapping cues trimmed
+  - <base>.review.md — human-readable summary of what was cut
+
+Stdlib only for the SRT side; subprocess + ffmpeg for the video side.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import shlex
+import subprocess
+import sys
+
+HERE = pathlib.Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+
+import clean_srt  # noqa: E402
+
+AUDIO_FADE = 0.012  # seconds of fade-in/out per kept segment edge
+
+
+def keep_ranges(cuts: list[dict], duration: float) -> list[tuple[float, float]]:
+    """Inverse of cuts: ranges we keep, in order, clamped to [0, duration]."""
+    intervals = sorted(((float(c["start"]), float(c["end"])) for c in cuts),
+                       key=lambda x: x[0])
+    out: list[tuple[float, float]] = []
+    cursor = 0.0
+    for s, e in intervals:
+        s = max(0.0, s)
+        e = min(duration, e)
+        if s > cursor:
+            out.append((cursor, s))
+        cursor = max(cursor, e)
+    if cursor < duration:
+        out.append((cursor, duration))
+    return [(s, e) for s, e in out if e - s > 0.01]
+
+
+def shift_srt(cues: list[clean_srt.Cue],
+              keeps: list[tuple[float, float]]) -> list[clean_srt.Cue]:
+    """Map original-timeline cues onto the cut timeline.
+
+    A cue that lies entirely inside a removed gap is dropped. A cue that
+    straddles a cut is trimmed to the kept side(s); we don't try to split
+    one cue into two — a presenter speaking across a cut would read very
+    oddly anyway, so we keep whichever side has more text.
+    """
+    if not keeps:
+        return list(cues)
+
+    # Build a piecewise-linear map: original_time -> new_time.
+    # For t inside keep[i] = (s, e), new_t = sum(prev keep durations) + (t - s).
+    new_starts = []
+    acc = 0.0
+    for s, e in keeps:
+        new_starts.append(acc - s)  # offset such that new_t = t + offset
+        acc += e - s
+
+    def map_time(t: float) -> float | None:
+        for (s, e), off in zip(keeps, new_starts):
+            if s <= t <= e:
+                return t + off
+        return None
+
+    out: list[clean_srt.Cue] = []
+    for cue in cues:
+        # Find the keep range that contains the majority of the cue.
+        best: tuple[float, float, float] | None = None  # (overlap, s, e)
+        for s, e in keeps:
+            ov = max(0.0, min(cue.end, e) - max(cue.start, s))
+            if ov > 0 and (best is None or ov > best[0]):
+                best = (ov, s, e)
+        if best is None:
+            continue
+        _, ks, ke = best
+        clipped_start = max(cue.start, ks)
+        clipped_end = min(cue.end, ke)
+        if clipped_end - clipped_start < 0.15:
+            continue
+        ns = map_time(clipped_start)
+        ne = map_time(clipped_end)
+        if ns is None or ne is None:
+            continue
+        out.append(clean_srt.Cue(len(out) + 1, ns, ne, cue.text))
+    return out
+
+
+def build_filter_complex(keeps: list[tuple[float, float]]) -> str:
+    parts = []
+    labels = []
+    for i, (s, e) in enumerate(keeps):
+        d = e - s
+        fade = min(AUDIO_FADE, d / 4)
+        parts.append(
+            f"[0:v]trim=start={s:.3f}:end={e:.3f},setpts=PTS-STARTPTS[v{i}];"
+            f"[0:a]atrim=start={s:.3f}:end={e:.3f},asetpts=PTS-STARTPTS,"
+            f"afade=t=in:st=0:d={fade:.3f},"
+            f"afade=t=out:st={max(0, d - fade):.3f}:d={fade:.3f}[a{i}]"
+        )
+        labels.append(f"[v{i}][a{i}]")
+    parts.append(f"{''.join(labels)}concat=n={len(keeps)}:v=1:a=1[outv][outa]")
+    return ";".join(parts)
+
+
+def write_review_md(cuts: list[dict], summary: dict, dst: pathlib.Path) -> None:
+    lines = ["# video-subtitle review", "",
+             f"Total cuts: **{summary['total']}** "
+             f"(filler {summary['filler']}, "
+             f"stutter {summary['stutter']}, "
+             f"silence {summary['long_silence']})",
+             "",
+             f"Total time removed: **{summary['total_duration_seconds']:.2f}s**",
+             "",
+             "If a cut is wrong, copy its `start-end` (in seconds) and re-run with",
+             "`run.sh ... --exclude-cut START-END`. The other steps are cached so",
+             "only the cut/burn-in passes will re-run.",
+             "",
+             "| # | Time | Reason | Text | Context |",
+             "|---|------|--------|------|---------|"]
+    for i, c in enumerate(cuts, 1):
+        lines.append(f"| {i} | {c['start']:.2f}-{c['end']:.2f} | "
+                     f"{c['reason']} | `{c['text']}` | {c['context']} |")
+    dst.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def ffprobe_duration(video: pathlib.Path) -> float:
+    out = subprocess.check_output([
+        "ffprobe", "-v", "error", "-show_entries", "format=duration",
+        "-of", "default=nw=1:nk=1", str(video),
+    ], text=True).strip()
+    return float(out)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("video")
+    ap.add_argument("srt")
+    ap.add_argument("cuts_json")
+    ap.add_argument("out_video")
+    ap.add_argument("out_srt")
+    ap.add_argument("--review-md")
+    ap.add_argument("--crf", type=int, default=17)
+    ap.add_argument("--preset", default="slow")
+    args = ap.parse_args()
+
+    with open(args.cuts_json, encoding="utf-8") as f:
+        payload = json.load(f)
+    cuts = payload.get("cuts", [])
+
+    video = pathlib.Path(args.video)
+    duration = ffprobe_duration(video)
+    keeps = keep_ranges(cuts, duration)
+
+    if args.review_md and cuts:
+        write_review_md(cuts, payload.get("summary", {}),
+                        pathlib.Path(args.review_md))
+
+    # Shift SRT on the original video's timeline -> cut timeline.
+    with open(args.srt, encoding="utf-8") as f:
+        cues = clean_srt.parse_srt(f.read())
+    new_cues = shift_srt(cues, keeps) if cuts else cues
+    new_cues = clean_srt.reindex(new_cues)
+    with open(args.out_srt, "w", encoding="utf-8") as f:
+        f.write(clean_srt.emit(new_cues))
+
+    if not cuts:
+        # No-op: copy through losslessly.
+        subprocess.check_call([
+            "ffmpeg", "-y", "-loglevel", "error", "-i", str(video),
+            "-c", "copy", "-movflags", "+faststart", args.out_video,
+        ])
+        print("apply_cuts: nothing to cut, copied through", file=sys.stderr)
+        return 0
+
+    filter_complex = build_filter_complex(keeps)
+    cmd = [
+        "ffmpeg", "-y", "-loglevel", "error",
+        "-i", str(video),
+        "-filter_complex", filter_complex,
+        "-map", "[outv]", "-map", "[outa]",
+        "-c:v", "libx264", "-crf", str(args.crf), "-preset", args.preset,
+        "-pix_fmt", "yuv420p",
+        "-c:a", "aac", "-b:a", "192k",
+        "-movflags", "+faststart",
+        args.out_video,
+    ]
+    print(f"apply_cuts: {len(cuts)} cuts, {len(keeps)} keep-ranges",
+          file=sys.stderr)
+    print(f"  ffmpeg: {' '.join(shlex.quote(c) for c in cmd[:8])} ...",
+          file=sys.stderr)
+    subprocess.check_call(cmd)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/video-subtitle/bootstrap.sh
+++ b/scripts/video-subtitle/bootstrap.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Install everything video-subtitle/run.sh needs. Safe to re-run.
+# Supported: Ubuntu/Debian (apt) and macOS (brew). Elsewhere: prints guidance.
+
+set -euo pipefail
+
+need_install=()
+for bin in ffmpeg ffprobe; do
+  command -v "$bin" >/dev/null 2>&1 || need_install+=("$bin")
+done
+
+have_fw=0
+python3 -c "import faster_whisper" >/dev/null 2>&1 && have_fw=1
+
+have_anthropic=0
+python3 -c "import anthropic, pydantic" >/dev/null 2>&1 && have_anthropic=1
+
+if [[ ${#need_install[@]} -eq 0 && $have_fw -eq 1 && $have_anthropic -eq 1 ]]; then
+  echo "bootstrap: all dependencies already present"
+  exit 0
+fi
+
+os="$(uname -s)"
+case "$os" in
+  Linux)
+    if ! command -v apt-get >/dev/null 2>&1; then
+      echo "bootstrap: apt-get not available; install ffmpeg + 'pip install faster-whisper' manually" >&2
+      exit 1
+    fi
+    SUDO=""
+    if [[ $EUID -ne 0 ]]; then
+      if command -v sudo >/dev/null 2>&1; then SUDO="sudo"; else
+        echo "bootstrap: need root or sudo to apt-get install" >&2; exit 1
+      fi
+    fi
+    if [[ ${#need_install[@]} -gt 0 ]]; then
+      echo "bootstrap: installing ffmpeg + fonts-noto-cjk via apt"
+      $SUDO apt-get update -qq
+      $SUDO apt-get install -y -qq ffmpeg fonts-noto-cjk
+    fi
+    ;;
+  Darwin)
+    if ! command -v brew >/dev/null 2>&1; then
+      echo "bootstrap: Homebrew not found; install from https://brew.sh first" >&2
+      exit 1
+    fi
+    if [[ ${#need_install[@]} -gt 0 ]]; then
+      echo "bootstrap: installing ffmpeg via brew"
+      brew install ffmpeg >/dev/null
+    fi
+    ;;
+  *)
+    echo "bootstrap: unsupported OS $os; install ffmpeg + 'pip install faster-whisper' manually" >&2
+    exit 1 ;;
+esac
+
+pip_install() {
+  # PEP 668: Ubuntu 24.04's system python is marked externally-managed.
+  python3 -m pip install --user --break-system-packages "$@"
+}
+
+if [[ $have_fw -eq 0 ]]; then
+  echo "bootstrap: installing faster-whisper"
+  if command -v pipx >/dev/null 2>&1; then
+    pipx install --include-deps faster-whisper >/dev/null 2>&1 || \
+      pip_install faster-whisper
+  else
+    pip_install faster-whisper
+  fi
+fi
+
+if [[ $have_anthropic -eq 0 ]]; then
+  echo "bootstrap: installing anthropic + pydantic (for proofread.py)"
+  pip_install "anthropic>=0.40" "pydantic>=2"
+fi
+
+echo "bootstrap: done"
+echo
+echo "Note: proofread.py requires ANTHROPIC_API_KEY in the environment."
+echo "      Set it via:  export ANTHROPIC_API_KEY=sk-ant-..."
+echo "      If unset, the proofread step is skipped automatically."

--- a/scripts/video-subtitle/clean_srt.py
+++ b/scripts/video-subtitle/clean_srt.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""Clean Whisper-generated SRT files.
+
+- Removes well-known trailing hallucinations (JA/EN).
+- Deduplicates consecutive identical cues.
+- Merges cues shorter than MIN_DURATION into their neighbours.
+- Splits cues longer than MAX_CHARS on punctuation.
+- Normalises whitespace (incl. full-width spaces).
+
+Stdlib only; no pysrt/pydub dependency.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+
+MIN_DURATION = 0.4  # seconds
+MAX_CHARS = 42  # per line (CJK counted as-is)
+
+HALLUCINATION_PATTERNS = {
+    "ja": [
+        r"^ご(視聴|清聴).*(ありがとう).*$",
+        r"^(最後|本日)までご視聴.*$",
+        r"^チャンネル登録.*お願い(します|いたします).?$",
+        r"^(いいね|高評価).*お願い(します|いたします).?$",
+        r"^次回もお楽しみに.?$",
+        r"^また(次回|お会いしましょう).?$",
+        r"^それでは(皆さん|また).*$",
+        r"^字幕.*(提供|作成|by|By|BY).*$",
+        r"^提供[:：].*$",
+        r"^おわり。?$",
+        r"^(以上|終わり)(です|でした)?。?$",
+    ],
+    "en": [
+        r"^thanks? for watching[\.!]*$",
+        r"^thank you for watching[\.!]*$",
+        r"^(please )?(like (and )?)?subscribe.*$",
+        r"^don'?t forget to (like|subscribe).*$",
+        r"^subtitles? by .*$",
+        r"^captions? by .*$",
+        r"^\[(music|applause|laughter)\]$",
+        r"^\(.*(music|applause)\).*$",
+    ],
+}
+
+# Matches "ABC" followed by at least 2 more repeats of the same 2-40 char run,
+# with optional whitespace/punctuation between. Catches Whisper's loop-mode
+# hallucinations like "ありがとうございましたありがとうございましたありがとうございました".
+_LOOP_RE = re.compile(r"(.{2,40}?)(?:[\s、。.,]*\1){2,}", re.DOTALL)
+
+
+@dataclass
+class Cue:
+    index: int
+    start: float
+    end: float
+    text: str
+
+    @property
+    def duration(self) -> float:
+        return self.end - self.start
+
+
+TIME_RE = re.compile(r"(\d{2}):(\d{2}):(\d{2})[,.](\d{3})")
+
+
+def parse_time(s: str) -> float:
+    m = TIME_RE.match(s.strip())
+    if not m:
+        raise ValueError(f"bad timestamp: {s!r}")
+    h, mi, se, ms = map(int, m.groups())
+    return h * 3600 + mi * 60 + se + ms / 1000.0
+
+
+def fmt_time(t: float) -> str:
+    if t < 0:
+        t = 0.0
+    h = int(t // 3600)
+    m = int((t % 3600) // 60)
+    s = int(t % 60)
+    ms = int(round((t - int(t)) * 1000))
+    if ms == 1000:
+        s += 1
+        ms = 0
+    return f"{h:02d}:{m:02d}:{s:02d},{ms:03d}"
+
+
+def parse_srt(text: str) -> list[Cue]:
+    # Normalise newlines and strip BOM.
+    text = text.lstrip("\ufeff").replace("\r\n", "\n").replace("\r", "\n")
+    blocks = re.split(r"\n{2,}", text.strip())
+    cues: list[Cue] = []
+    for block in blocks:
+        lines = [ln for ln in block.split("\n") if ln.strip() != ""]
+        if len(lines) < 2:
+            continue
+        idx_line = lines[0].strip()
+        time_line = lines[1] if "-->" in lines[1] else None
+        if time_line is None:
+            # Some exporters drop the numeric index line.
+            if "-->" in lines[0]:
+                time_line = lines[0]
+                body = lines[1:]
+                idx_line = str(len(cues) + 1)
+            else:
+                continue
+        else:
+            body = lines[2:]
+        try:
+            idx = int(idx_line)
+        except ValueError:
+            idx = len(cues) + 1
+        try:
+            start_s, end_s = [p.strip() for p in time_line.split("-->")]
+            start = parse_time(start_s)
+            end = parse_time(end_s)
+        except ValueError:
+            continue
+        cues.append(Cue(idx, start, end, "\n".join(body).strip()))
+    return cues
+
+
+def normalise_text(s: str) -> str:
+    s = s.replace("\u3000", " ")  # full-width space
+    s = re.sub(r"[ \t]+", " ", s)
+    s = re.sub(r" *\n *", "\n", s)
+    return s.strip()
+
+
+def strip_hallucinations(cues: list[Cue], lang: str) -> list[Cue]:
+    patterns = [re.compile(p, re.IGNORECASE) for p in HALLUCINATION_PATTERNS.get(lang, [])]
+    if not patterns:
+        return cues
+    cleaned: list[Cue] = []
+    for cue in cues:
+        stripped_body = "\n".join(
+            line for line in cue.text.split("\n")
+            if not any(p.match(line.strip()) for p in patterns)
+        ).strip()
+        if stripped_body:
+            cleaned.append(Cue(cue.index, cue.start, cue.end, stripped_body))
+    # Trim a trailing hallucination-only cue (common Whisper artefact).
+    while cleaned and cleaned[-1].text == "":
+        cleaned.pop()
+    return cleaned
+
+
+def collapse_repetition_loops(text: str) -> str:
+    """Collapse 3+ consecutive repeats of any 2-40 char substring down to one.
+
+    Whisper occasionally gets stuck in a decoding loop, producing output like
+    "ありがとうございましたありがとうございましたありがとうございました". This is
+    distinct from a presenter actually saying something three times — those
+    usually have different surrounding context and varied spacing, so the
+    strict >=3 threshold avoids false positives on legitimate repetition.
+    """
+    prev = None
+    while text != prev:
+        prev = text
+        text = _LOOP_RE.sub(r"\1", text)
+    return text
+
+
+def collapse_loops_in_cues(cues: list[Cue]) -> list[Cue]:
+    out: list[Cue] = []
+    for cue in cues:
+        collapsed = collapse_repetition_loops(cue.text).strip()
+        if collapsed:
+            out.append(Cue(cue.index, cue.start, cue.end, collapsed))
+    return out
+
+
+def dedupe_consecutive(cues: list[Cue]) -> list[Cue]:
+    out: list[Cue] = []
+    for cue in cues:
+        if out and out[-1].text == cue.text and cue.start - out[-1].end < 0.5:
+            out[-1] = Cue(out[-1].index, out[-1].start, cue.end, cue.text)
+        else:
+            out.append(cue)
+    return out
+
+
+def merge_too_short(cues: list[Cue]) -> list[Cue]:
+    # First pass: merge into the previous cue when possible.
+    out: list[Cue] = []
+    pending: Cue | None = None
+    for cue in cues:
+        if cue.duration < MIN_DURATION:
+            if out:
+                prev = out[-1]
+                out[-1] = Cue(prev.index, prev.start, max(prev.end, cue.end),
+                              (prev.text + " " + cue.text).strip())
+            else:
+                # No previous cue yet; carry forward to merge with the next one.
+                pending = cue if pending is None else Cue(
+                    pending.index, pending.start, cue.end,
+                    (pending.text + " " + cue.text).strip())
+        else:
+            if pending is not None:
+                cue = Cue(pending.index, pending.start, cue.end,
+                          (pending.text + " " + cue.text).strip())
+                pending = None
+            out.append(cue)
+    if pending is not None:
+        out.append(pending)
+    return out
+
+
+def split_too_long(cues: list[Cue]) -> list[Cue]:
+    out: list[Cue] = []
+    for cue in cues:
+        lines = cue.text.split("\n")
+        if all(len(line) <= MAX_CHARS for line in lines):
+            out.append(cue)
+            continue
+        # Split on sentence-ish punctuation while keeping timing proportional to char count.
+        flat = cue.text.replace("\n", " ")
+        parts = re.split(r"(?<=[。．.!?！？])\s*", flat)
+        parts = [p for p in (p.strip() for p in parts) if p]
+        if len(parts) <= 1:
+            out.append(cue)
+            continue
+        total_chars = sum(len(p) for p in parts)
+        if total_chars == 0:
+            out.append(cue)
+            continue
+        t = cue.start
+        for p in parts:
+            frac = len(p) / total_chars
+            end = t + cue.duration * frac
+            out.append(Cue(cue.index, t, end, p))
+            t = end
+        # Guarantee the final chunk ends exactly at cue.end to avoid drift.
+        if out and out[-1].start < cue.end:
+            out[-1] = Cue(out[-1].index, out[-1].start, cue.end, out[-1].text)
+    return out
+
+
+def reindex(cues: list[Cue]) -> list[Cue]:
+    return [Cue(i + 1, c.start, c.end, c.text) for i, c in enumerate(cues)]
+
+
+def emit(cues: list[Cue]) -> str:
+    chunks = []
+    for c in cues:
+        chunks.append(f"{c.index}\n{fmt_time(c.start)} --> {fmt_time(c.end)}\n{c.text}\n")
+    return "\n".join(chunks) + "\n"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("src")
+    ap.add_argument("dst")
+    ap.add_argument("--lang", default="ja")
+    args = ap.parse_args()
+
+    with open(args.src, encoding="utf-8") as f:
+        cues = parse_srt(f.read())
+    if not cues:
+        print(f"no cues parsed from {args.src}", file=sys.stderr)
+        return 1
+
+    cues = [Cue(c.index, c.start, c.end, normalise_text(c.text)) for c in cues]
+    cues = collapse_loops_in_cues(cues)
+    cues = strip_hallucinations(cues, args.lang)
+    cues = dedupe_consecutive(cues)
+    cues = merge_too_short(cues)
+    cues = split_too_long(cues)
+    cues = reindex(cues)
+
+    with open(args.dst, "w", encoding="utf-8") as f:
+        f.write(emit(cues))
+    print(f"wrote {len(cues)} cues -> {args.dst}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/video-subtitle/detect_fillers.py
+++ b/scripts/video-subtitle/detect_fillers.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Detect fillers, stutters and long silences from Whisper word timestamps.
+
+Reads ``<base>.words.json`` (written by transcribe.py) and emits
+``<base>.cuts.json``: every range we propose to remove from the video, with
+the reason and surrounding text so a human can review.
+
+Defaults are conservative — only unambiguous JA fillers ("えー" / "えーと" /
+"あー" / "うー" / "えっと"). The aggressive set ("あの" / "まあ" / "なんか" /
+"ちょっと") is opt-in via --aggressive because those words have meaning in
+context and over-cutting was the original Premiere pain.
+
+Stdlib only.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import asdict, dataclass
+
+CONSERVATIVE_FILLERS = {
+    "えー", "えーっ", "えーと", "えっと", "あー", "あーっ",
+    "うー", "うーん", "んー", "んーと",
+}
+
+AGGRESSIVE_FILLERS = CONSERVATIVE_FILLERS | {
+    "あの", "あのー", "あのう",
+    "まあ", "まぁ",
+    "なんか",
+    "ちょっと",
+    "その", "そのー",
+}
+
+# Surrounding-pad applied to every cut so we don't clip the leading consonant
+# of the next word or the trailing tail of the previous one.
+HEAD_PAD = 0.04  # seconds
+TAIL_PAD = 0.04  # seconds
+
+STUTTER_GAP = 0.6   # max silence between repeats counted as a stutter
+LONG_SILENCE_KEEP = 0.3  # how much silence to keep when trimming a long pause
+
+
+@dataclass
+class Cut:
+    start: float
+    end: float
+    reason: str  # "filler" | "stutter" | "long_silence"
+    text: str
+    context: str  # ~30 chars around the cut for human review
+
+
+def _normalise(word: str) -> str:
+    # Strip trailing punctuation Whisper sometimes attaches and squash
+    # the long-vowel mark variants so "えー" / "えーっ" / "ええ" all match.
+    s = re.sub(r"[、。.,!?！？\s]+$", "", word.strip())
+    s = s.replace("ー", "").replace("っ", "").replace("ぁ", "あ").replace("ぃ", "い")
+    s = s.replace("ぅ", "う").replace("ぇ", "え").replace("ぉ", "お")
+    return s
+
+
+def _matches_filler(word: str, dictionary: set[str]) -> bool:
+    if word in dictionary:
+        return True
+    return _normalise(word) in {_normalise(w) for w in dictionary}
+
+
+def _ctx(words: list[dict], i: int, span: int = 4) -> str:
+    lo, hi = max(0, i - span), min(len(words), i + span + 1)
+    parts = []
+    for j in range(lo, hi):
+        token = words[j].get("word", "")
+        parts.append(f"[{token}]" if j == i else token)
+    return "".join(parts).strip()
+
+
+def detect(words: list[dict], *,
+           dictionary: set[str],
+           detect_stutters: bool = True,
+           silence_threshold: float | None = None) -> list[Cut]:
+    cuts: list[Cut] = []
+
+    # Pass 1: filler words.
+    for i, w in enumerate(words):
+        token = (w.get("word") or "").strip()
+        if not token:
+            continue
+        if _matches_filler(token, dictionary):
+            cuts.append(Cut(
+                start=max(0.0, float(w["start"]) - HEAD_PAD),
+                end=float(w["end"]) + TAIL_PAD,
+                reason="filler",
+                text=token,
+                context=_ctx(words, i),
+            ))
+
+    # Pass 2: stutter — same normalised word repeated 3+ times within
+    # STUTTER_GAP seconds of each other. Cut all but the last occurrence,
+    # so "あの あの あの 始めます" keeps the final "あの 始めます".
+    if detect_stutters:
+        run_start = 0
+        for i in range(1, len(words) + 1):
+            same_run = (
+                i < len(words)
+                and _normalise(words[i].get("word", "")) ==
+                    _normalise(words[i - 1].get("word", ""))
+                and float(words[i]["start"]) - float(words[i - 1]["end"]) <= STUTTER_GAP
+                and _normalise(words[i].get("word", "")) != ""
+            )
+            if not same_run:
+                run_len = i - run_start
+                if run_len >= 3:
+                    # Drop everything from run_start up to (not including) the
+                    # last occurrence at i - 1.
+                    drop_end = i - 1
+                    for j in range(run_start, drop_end):
+                        cuts.append(Cut(
+                            start=max(0.0, float(words[j]["start"]) - HEAD_PAD),
+                            end=float(words[j]["end"]) + TAIL_PAD,
+                            reason="stutter",
+                            text=words[j].get("word", ""),
+                            context=_ctx(words, j),
+                        ))
+                run_start = i
+
+    # Pass 3: long silences (opt-in via threshold). Trim down to LONG_SILENCE_KEEP
+    # so the output doesn't sound clipped.
+    if silence_threshold is not None and silence_threshold > 0:
+        for i in range(1, len(words)):
+            gap = float(words[i]["start"]) - float(words[i - 1]["end"])
+            if gap > silence_threshold:
+                trim = gap - LONG_SILENCE_KEEP
+                cut_start = float(words[i - 1]["end"]) + LONG_SILENCE_KEEP / 2
+                cut_end = cut_start + trim
+                cuts.append(Cut(
+                    start=cut_start,
+                    end=cut_end,
+                    reason="long_silence",
+                    text=f"[silence {gap:.2f}s]",
+                    context=_ctx(words, i),
+                ))
+
+    cuts.sort(key=lambda c: c.start)
+    return _merge_overlaps(cuts)
+
+
+def _merge_overlaps(cuts: list[Cut]) -> list[Cut]:
+    if not cuts:
+        return []
+    out = [cuts[0]]
+    for c in cuts[1:]:
+        prev = out[-1]
+        if c.start <= prev.end:
+            out[-1] = Cut(
+                start=prev.start,
+                end=max(prev.end, c.end),
+                reason=prev.reason if prev.reason == c.reason else "merged",
+                text=(prev.text + " " + c.text).strip(),
+                context=prev.context,
+            )
+        else:
+            out.append(c)
+    return out
+
+
+def apply_excludes(cuts: list[Cut], excludes: list[tuple[float, float]]) -> list[Cut]:
+    """Drop any cut whose midpoint falls inside an excluded range."""
+    if not excludes:
+        return cuts
+    kept = []
+    for c in cuts:
+        mid = (c.start + c.end) / 2
+        if not any(s <= mid <= e for s, e in excludes):
+            kept.append(c)
+    return kept
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("words_json")
+    ap.add_argument("cuts_json")
+    ap.add_argument("--aggressive", action="store_true",
+                    help="Include 'あの', 'まあ', 'なんか', 'ちょっと' in the filler set")
+    ap.add_argument("--no-stutters", action="store_true")
+    ap.add_argument("--silence-threshold", type=float, default=None,
+                    help="Trim silences longer than N seconds down to ~0.3s "
+                         "(off by default)")
+    ap.add_argument("--exclude", action="append", default=[],
+                    help="Time range to never cut, format start-end in seconds. "
+                         "Repeatable.")
+    args = ap.parse_args()
+
+    with open(args.words_json, encoding="utf-8") as f:
+        words = json.load(f)
+    if not words:
+        print("no words to process", file=sys.stderr)
+        with open(args.cuts_json, "w", encoding="utf-8") as f:
+            json.dump({"cuts": [], "excluded": []}, f, ensure_ascii=False, indent=2)
+        return 0
+
+    excludes: list[tuple[float, float]] = []
+    for e in args.exclude:
+        s, _, end = e.partition("-")
+        excludes.append((float(s), float(end)))
+
+    dictionary = AGGRESSIVE_FILLERS if args.aggressive else CONSERVATIVE_FILLERS
+    cuts = detect(
+        words,
+        dictionary=dictionary,
+        detect_stutters=not args.no_stutters,
+        silence_threshold=args.silence_threshold,
+    )
+    cuts = apply_excludes(cuts, excludes)
+
+    payload = {
+        "cuts": [asdict(c) for c in cuts],
+        "excluded": [{"start": s, "end": e} for s, e in excludes],
+        "summary": {
+            "total": len(cuts),
+            "filler": sum(1 for c in cuts if c.reason == "filler"),
+            "stutter": sum(1 for c in cuts if c.reason == "stutter"),
+            "long_silence": sum(1 for c in cuts if c.reason == "long_silence"),
+            "total_duration_seconds": round(sum(c.end - c.start for c in cuts), 3),
+        },
+    }
+    with open(args.cuts_json, "w", encoding="utf-8") as f:
+        json.dump(payload, f, ensure_ascii=False, indent=2)
+
+    print(f"detect_fillers: {payload['summary']['total']} cuts "
+          f"({payload['summary']['filler']} filler, "
+          f"{payload['summary']['stutter']} stutter, "
+          f"{payload['summary']['long_silence']} silence) "
+          f"= {payload['summary']['total_duration_seconds']}s",
+          file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/video-subtitle/glossary.txt
+++ b/scripts/video-subtitle/glossary.txt
@@ -1,0 +1,29 @@
+# video-subtitle: terminology glossary
+#
+# One term per line. Lines starting with # are comments.
+# Used by:
+#   - transcribe.py as Whisper's `initial_prompt` (improves recognition)
+#   - proofread.py as a Claude system-prompt block (corrects misrecognitions)
+#
+# Add proper nouns, brand names, technical terms, anything Whisper tends to
+# mishear. Edit freely; the file is cached by Claude so updates trigger one
+# extra cache write then settle back to ~0.1x cost per chunk.
+
+# Internal
+Lumenium
+
+# Stack
+Next.js
+Vercel
+TypeScript
+React
+PostgreSQL
+Tailwind CSS
+
+# Tools mentioned in production
+Premiere Pro
+Adobe
+Whisper
+ffmpeg
+Claude
+Claude Code

--- a/scripts/video-subtitle/proofread.py
+++ b/scripts/video-subtitle/proofread.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Proofread a cleaned SRT via Claude (Sonnet 4.6) with prompt caching.
+
+Splits the SRT into 40-cue chunks. For each chunk, sends a system prompt
+plus glossary as a cached prefix and the chunk-as-JSON as the user message.
+Receives structured edits {cue_index, original, corrected, reason} and
+applies them in place. Writes ``<base>.proofread.srt`` plus a
+``<base>.proofread.diff`` showing every change.
+
+The first chunk pays the full cost; subsequent chunks read the cached
+glossary + instructions and only pay for the chunk itself. Verify with
+the cache_read_input_tokens line printed at the end.
+
+Quality knobs we deliberately *don't* relax:
+  - We never alter timestamps. Timing is the cut/Whisper layer's job.
+  - We never delete a cue. If the model proposes ``corrected: ""`` we ignore it.
+  - We never rewrite — the prompt asks for minimal local edits only.
+"""
+from __future__ import annotations
+
+import argparse
+import difflib
+import json
+import os
+import pathlib
+import sys
+from typing import List, Optional
+
+HERE = pathlib.Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+
+import clean_srt  # noqa: E402
+
+CHUNK_SIZE = 40
+
+INSTRUCTIONS = """You are a Japanese video subtitle proofreader.
+
+Your job is to apply minimal local edits to a Whisper-generated transcript:
+correct typos, restore proper nouns and product names, fix kana/kanji
+confusions, and normalise punctuation. Do NOT rewrite for style or fluency.
+Do NOT shorten, expand, or rephrase. Preserve speaker meaning verbatim.
+
+Input is a JSON array of subtitle cues:
+  [{"index": 7, "text": "..."}, ...]
+
+Return JSON matching the schema you've been given. Include an entry only
+when you are *changing* the text. If no changes are needed, return
+{"edits": []}.
+
+Style rules:
+- Use 全角 punctuation (、。「」) consistently.
+- Keep contractions and spoken style intact ("やってる" stays "やってる").
+- For ambiguous proper nouns, prefer the spelling in the GLOSSARY block.
+- Never delete a cue (corrected text must be non-empty).
+- Never merge cues (one cue index per edit).
+"""
+
+
+def load_glossary(path: pathlib.Path) -> str:
+    if not path.exists():
+        return "(no glossary file provided)"
+    terms = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        s = line.strip()
+        if not s or s.startswith("#"):
+            continue
+        terms.append(s)
+    if not terms:
+        return "(empty glossary)"
+    body = "\n".join(f"- {t}" for t in terms)
+    return f"GLOSSARY (canonical spellings — prefer these over Whisper's output):\n{body}"
+
+
+def chunked(cues: list[clean_srt.Cue], size: int):
+    for i in range(0, len(cues), size):
+        yield cues[i:i + size]
+
+
+def build_diff(orig: list[clean_srt.Cue], new: list[clean_srt.Cue]) -> str:
+    o_lines = [f"{c.index}: {c.text}" for c in orig]
+    n_lines = [f"{c.index}: {c.text}" for c in new]
+    return "\n".join(difflib.unified_diff(
+        o_lines, n_lines, fromfile="original", tofile="proofread", lineterm=""))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("src")
+    ap.add_argument("dst")
+    ap.add_argument("--glossary", required=True)
+    ap.add_argument("--diff")
+    ap.add_argument("--model", default="claude-sonnet-4-6")
+    ap.add_argument("--cache-ttl", default="5m", choices=["5m", "1h"])
+    args = ap.parse_args()
+
+    if not os.environ.get("ANTHROPIC_API_KEY"):
+        print("proofread: ANTHROPIC_API_KEY not set; skipping (copying input through)",
+              file=sys.stderr)
+        pathlib.Path(args.dst).write_text(
+            pathlib.Path(args.src).read_text(encoding="utf-8"), encoding="utf-8")
+        return 0
+
+    try:
+        import anthropic  # type: ignore
+        from pydantic import BaseModel, Field  # type: ignore
+    except ImportError:
+        print("proofread: anthropic + pydantic not installed; "
+              "run scripts/video-subtitle/bootstrap.sh", file=sys.stderr)
+        return 127
+
+    class Edit(BaseModel):
+        cue_index: int = Field(..., description="The 'index' field from the input cue")
+        original: str = Field(..., description="The cue text as received")
+        corrected: str = Field(..., description="The corrected cue text (non-empty)")
+        reason: str = Field(..., description="One of: typo, terminology, punctuation, kana_kanji")
+
+    class ProofreadResult(BaseModel):
+        edits: List[Edit] = Field(default_factory=list)
+
+    glossary_text = load_glossary(pathlib.Path(args.glossary))
+
+    client = anthropic.Anthropic()
+    cues = clean_srt.parse_srt(pathlib.Path(args.src).read_text(encoding="utf-8"))
+    if not cues:
+        pathlib.Path(args.dst).write_text("", encoding="utf-8")
+        return 0
+
+    edited: dict[int, str] = {}
+    total_in = total_out = total_cached_read = total_cached_write = 0
+
+    cache_ctrl = {"type": "ephemeral"}
+    if args.cache_ttl == "1h":
+        cache_ctrl["ttl"] = "1h"
+
+    chunks = list(chunked(cues, CHUNK_SIZE))
+    for n, chunk in enumerate(chunks, 1):
+        payload = json.dumps(
+            [{"index": c.index, "text": c.text} for c in chunk],
+            ensure_ascii=False,
+        )
+        try:
+            resp = client.messages.parse(
+                model=args.model,
+                max_tokens=8192,
+                system=[
+                    {"type": "text", "text": INSTRUCTIONS},
+                    # cache_control on the LAST system block caches tools+system
+                    # together — both INSTRUCTIONS and the glossary stay warm.
+                    {"type": "text", "text": glossary_text, "cache_control": cache_ctrl},
+                ],
+                messages=[{"role": "user",
+                           "content": f"Proofread these cues:\n\n{payload}"}],
+                output_format=ProofreadResult,
+            )
+        except anthropic.APIStatusError as e:
+            print(f"proofread: API error on chunk {n}/{len(chunks)} "
+                  f"(status {e.status_code}); skipping this chunk", file=sys.stderr)
+            continue
+
+        result: ProofreadResult = resp.parsed_output
+        for edit in result.edits:
+            if not edit.corrected.strip():
+                continue
+            if edit.corrected == edit.original:
+                continue
+            edited[edit.cue_index] = edit.corrected
+
+        u = resp.usage
+        total_in += u.input_tokens
+        total_out += u.output_tokens
+        total_cached_read += getattr(u, "cache_read_input_tokens", 0) or 0
+        total_cached_write += getattr(u, "cache_creation_input_tokens", 0) or 0
+        print(f"proofread: chunk {n}/{len(chunks)} "
+              f"in={u.input_tokens} out={u.output_tokens} "
+              f"cache_read={getattr(u, 'cache_read_input_tokens', 0) or 0} "
+              f"edits={len(result.edits)}", file=sys.stderr)
+
+    new_cues = [
+        clean_srt.Cue(c.index, c.start, c.end, edited.get(c.index, c.text))
+        for c in cues
+    ]
+    pathlib.Path(args.dst).write_text(clean_srt.emit(new_cues), encoding="utf-8")
+
+    if args.diff:
+        pathlib.Path(args.diff).write_text(build_diff(cues, new_cues), encoding="utf-8")
+
+    print(f"proofread: applied {len(edited)} edits across {len(cues)} cues",
+          file=sys.stderr)
+    print(f"proofread: tokens in={total_in} out={total_out} "
+          f"cache_read={total_cached_read} cache_write={total_cached_write}",
+          file=sys.stderr)
+    if total_cached_write > 0 and total_cached_read == 0 and len(chunks) > 1:
+        print("proofread: WARNING — cache wrote but never read; check that "
+              "the glossary file is large enough to cross the cacheable "
+              "prefix threshold (Sonnet 4.6 = 2048 tokens).", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/video-subtitle/run.sh
+++ b/scripts/video-subtitle/run.sh
@@ -1,0 +1,309 @@
+#!/usr/bin/env bash
+# video-subtitle full pipeline (quality-first):
+#   ffmpeg extract -> 2-pass loudnorm -> faster-whisper (full precision, VAD,
+#   word timestamps) -> clean SRT -> Claude proofread (cached glossary) ->
+#   filler/stutter detection -> ffmpeg cuts (audio fades) -> visually-lossless
+#   burn-in
+#
+# Every step's output is cached on disk; rerun the same command to resume,
+# or delete a specific intermediate to force one stage to recompute.
+# See .claude/skills/video-subtitle/SKILL.md for usage.
+
+set -euo pipefail
+
+LANG_CODE="ja"
+MODEL="large-v3"
+BEAM=10
+BURN=1
+PREVIEW=0
+NORMALIZE=1
+PROOFREAD=1
+CUT=1
+AGGRESSIVE_FILLERS=0
+SILENCE_THRESHOLD=""
+EXCLUDE_CUTS=()
+PROMPT=""
+GLOSSARY=""
+CRF=17
+PRESET="slow"
+case "$(uname -s)" in
+  Darwin) FONT="Hiragino Sans" ;;
+  *)      FONT="Noto Sans CJK JP" ;;
+esac
+FONTSIZE=0
+OUT_DIR=""
+INPUT=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --lang) LANG_CODE="$2"; shift 2 ;;
+    --model) MODEL="$2"; shift 2 ;;
+    --beam) BEAM="$2"; shift 2 ;;
+    --no-burn) BURN=0; shift ;;
+    --preview) PREVIEW=1; shift ;;
+    --no-normalize) NORMALIZE=0; shift ;;
+    --no-proofread) PROOFREAD=0; shift ;;
+    --no-cut) CUT=0; shift ;;
+    --aggressive-fillers) AGGRESSIVE_FILLERS=1; shift ;;
+    --silence-threshold) SILENCE_THRESHOLD="$2"; shift 2 ;;
+    --exclude-cut) EXCLUDE_CUTS+=("$2"); shift 2 ;;
+    --prompt) PROMPT="$2"; shift 2 ;;
+    --glossary) GLOSSARY="$2"; shift 2 ;;
+    --crf) CRF="$2"; shift 2 ;;
+    --preset) PRESET="$2"; shift 2 ;;
+    --font) FONT="$2"; shift 2 ;;
+    --fontsize) FONTSIZE="$2"; shift 2 ;;
+    --out) OUT_DIR="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '1,80p' "$(dirname "$0")/../../.claude/skills/video-subtitle/SKILL.md"
+      exit 0 ;;
+    -*)
+      echo "unknown option: $1" >&2; exit 2 ;;
+    *)
+      if [[ -z "$INPUT" ]]; then INPUT="$1"; else
+        echo "multiple inputs not supported: $1" >&2; exit 2
+      fi
+      shift ;;
+  esac
+done
+
+if [[ -z "$INPUT" ]]; then
+  cat >&2 <<'USAGE'
+usage: run.sh <input-video> [options]
+  --lang <code>             ja|en|... (default ja)
+  --model <name>            tiny|base|small|medium|large-v3 (default large-v3)
+  --beam <n>                beam_size for Whisper (default 10)
+  --prompt <text>           initial_prompt for Whisper
+  --glossary <path>         glossary file for Whisper + Claude (default: scripts/video-subtitle/glossary.txt)
+  --no-proofread            skip Claude SRT proofreading step
+  --no-cut                  skip filler/stutter detection and cutting
+  --aggressive-fillers      include 'あの', 'まあ', 'なんか', 'ちょっと'
+  --silence-threshold <n>   trim silences longer than N seconds (off by default)
+  --exclude-cut START-END   protect a time range from being cut (repeatable)
+  --preview                 tiny model + skip burn/loudnorm/cut/proofread (text preview)
+  --no-burn                 emit cleaned/proofread SRT only; skip burn-in
+  --no-normalize            skip 2-pass loudnorm
+  --crf <n>                 libx264 CRF for burn-in (default 17 = visually lossless)
+  --preset <name>           libx264 preset (default slow)
+  --font <name>             burn-in font family
+  --fontsize <n>            burn-in font size (0 = auto from video height)
+  --out <dir>               output directory (default: input dir)
+USAGE
+  exit 2
+fi
+
+if [[ ! -f "$INPUT" ]]; then
+  echo "input not found: $INPUT" >&2; exit 1
+fi
+
+if [[ "$PREVIEW" -eq 1 ]]; then
+  MODEL="tiny"
+  BEAM=5
+  BURN=0
+  NORMALIZE=0
+  PROOFREAD=0
+  CUT=0
+fi
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+[[ -z "$GLOSSARY" ]] && GLOSSARY="$script_dir/glossary.txt"
+
+# Bootstrap once.
+need_bootstrap=0
+for bin in ffmpeg ffprobe; do
+  command -v "$bin" >/dev/null 2>&1 || need_bootstrap=1
+done
+python3 -c "import faster_whisper" >/dev/null 2>&1 || need_bootstrap=1
+if [[ "$PROOFREAD" -eq 1 ]]; then
+  python3 -c "import anthropic, pydantic" >/dev/null 2>&1 || need_bootstrap=1
+fi
+if [[ "$need_bootstrap" -eq 1 ]]; then
+  echo "[0/8] bootstrapping dependencies"
+  bash "$script_dir/bootstrap.sh"
+fi
+
+abs_input="$(cd "$(dirname "$INPUT")" && pwd)/$(basename "$INPUT")"
+base="$(basename "${INPUT%.*}")"
+dir="${OUT_DIR:-$(dirname "$abs_input")}"
+mkdir -p "$dir"
+
+raw_wav="$dir/$base.raw.wav"
+wav="$dir/$base.wav"
+raw_srt="$dir/$base.raw.srt"
+words_json="$dir/$base.words.json"
+clean_srt_out="$dir/$base.clean.srt"
+proofread_srt="$dir/$base.proofread.srt"
+proofread_diff="$dir/$base.proofread.diff"
+final_srt="$dir/$base.srt"           # final pre-cut SRT (proofread or clean)
+cuts_json="$dir/$base.cuts.json"
+review_md="$dir/$base.review.md"
+cut_video="$dir/$base.cut.mp4"
+cut_srt="$dir/$base.cut.srt"
+out_mp4="$dir/$base.subtitled.mp4"
+
+# If a glossary is configured, prepend its content to the Whisper prompt
+# so terminology lands right at recognition time, before proofread fixes it.
+prompt_text="$PROMPT"
+if [[ -f "$GLOSSARY" ]]; then
+  glossary_terms="$(grep -v '^#' "$GLOSSARY" | grep -v '^[[:space:]]*$' | tr '\n' ' ')"
+  if [[ -n "$prompt_text" ]]; then
+    prompt_text="$prompt_text $glossary_terms"
+  else
+    prompt_text="$glossary_terms"
+  fi
+fi
+
+# ────────────────── [1] extract audio ──────────────────
+echo "[1/8] extracting audio -> $raw_wav"
+if [[ ! -f "$raw_wav" ]]; then
+  ffmpeg -y -loglevel error -i "$abs_input" \
+    -vn -ac 1 -ar 16000 -af "highpass=f=80" -c:a pcm_s16le "$raw_wav"
+else
+  echo "  (cached, skipping)"
+fi
+
+# ────────────────── [2] loudness normalisation ──────────────────
+echo "[2/8] loudness normalisation -> $wav"
+if [[ ! -f "$wav" ]]; then
+  if [[ "$NORMALIZE" -eq 1 ]]; then
+    echo "  pass 1/2: measuring integrated loudness"
+    measure_json=$(ffmpeg -hide_banner -nostats -i "$raw_wav" \
+      -af "loudnorm=I=-16:LRA=11:TP=-1.5:print_format=json" \
+      -f null - 2>&1 | awk '/^\{$/,/^\}$/')
+    if [[ -z "$measure_json" ]]; then
+      echo "  loudnorm measurement failed; falling back to single-pass" >&2
+      ffmpeg -y -loglevel error -i "$raw_wav" \
+        -af "loudnorm=I=-16:LRA=11:TP=-1.5" \
+        -ar 16000 -ac 1 -c:a pcm_s16le "$wav"
+    else
+      read measured_I measured_LRA measured_TP measured_thresh offset < <(
+        python3 - "$measure_json" <<'PY'
+import json, sys
+d = json.loads(sys.argv[1])
+off = float(d.get("target_offset", 0.0))
+off = max(min(off, 99.0), -99.0)
+print(d["input_i"], d["input_lra"], d["input_tp"], d["input_thresh"], off)
+PY
+      )
+      echo "  pass 2/2: applying measured=$measured_I LUFS -> target -16 LUFS"
+      ffmpeg -y -loglevel error -i "$raw_wav" \
+        -af "loudnorm=I=-16:LRA=11:TP=-1.5:\
+measured_I=$measured_I:measured_LRA=$measured_LRA:\
+measured_TP=$measured_TP:measured_thresh=$measured_thresh:\
+offset=$offset:linear=true:print_format=summary" \
+        -ar 16000 -ac 1 -c:a pcm_s16le "$wav"
+    fi
+  else
+    cp "$raw_wav" "$wav"
+  fi
+else
+  echo "  (cached, skipping)"
+fi
+
+# ────────────────── [3] faster-whisper ──────────────────
+echo "[3/8] faster-whisper ($MODEL, lang=$LANG_CODE, beam=$BEAM) -> $raw_srt + $words_json"
+if [[ ! -f "$raw_srt" || ! -f "$words_json" ]]; then
+  prompt_args=()
+  [[ -n "$prompt_text" ]] && prompt_args=(--prompt "$prompt_text")
+  python3 "$script_dir/transcribe.py" \
+    --lang "$LANG_CODE" --model "$MODEL" --beam-size "$BEAM" \
+    --words-json "$words_json" \
+    "${prompt_args[@]}" "$wav" "$raw_srt"
+else
+  echo "  (cached, skipping)"
+fi
+
+# ────────────────── [4] cleaner ──────────────────
+echo "[4/8] cleaning SRT -> $clean_srt_out"
+python3 "$script_dir/clean_srt.py" --lang "$LANG_CODE" "$raw_srt" "$clean_srt_out"
+
+# ────────────────── [5] Claude proofread ──────────────────
+if [[ "$PROOFREAD" -eq 1 ]]; then
+  echo "[5/8] Claude proofread -> $proofread_srt"
+  if [[ ! -f "$proofread_srt" ]]; then
+    python3 "$script_dir/proofread.py" \
+      --glossary "$GLOSSARY" \
+      --diff "$proofread_diff" \
+      "$clean_srt_out" "$proofread_srt"
+  else
+    echo "  (cached, skipping — delete $proofread_srt to re-run)"
+  fi
+  cp "$proofread_srt" "$final_srt"
+else
+  echo "[5/8] proofread disabled, copying clean -> final"
+  cp "$clean_srt_out" "$final_srt"
+fi
+
+# ────────────────── [6] filler / stutter detection ──────────────────
+if [[ "$CUT" -eq 1 ]]; then
+  echo "[6/8] filler/stutter detection -> $cuts_json"
+  detect_args=("$words_json" "$cuts_json")
+  [[ "$AGGRESSIVE_FILLERS" -eq 1 ]] && detect_args+=(--aggressive)
+  [[ -n "$SILENCE_THRESHOLD" ]] && detect_args+=(--silence-threshold "$SILENCE_THRESHOLD")
+  for ex in "${EXCLUDE_CUTS[@]}"; do
+    detect_args+=(--exclude "$ex")
+  done
+  python3 "$script_dir/detect_fillers.py" "${detect_args[@]}"
+else
+  echo "[6/8] cuts disabled, no cuts.json generated"
+  echo '{"cuts":[],"summary":{"total":0,"filler":0,"stutter":0,"long_silence":0,"total_duration_seconds":0}}' \
+    > "$cuts_json"
+fi
+
+# ────────────────── [7] apply cuts ──────────────────
+if [[ "$CUT" -eq 1 ]] && python3 -c "
+import json, sys
+sys.exit(0 if json.load(open('$cuts_json'))['cuts'] else 1)
+" 2>/dev/null; then
+  echo "[7/8] applying cuts -> $cut_video + $cut_srt"
+  python3 "$script_dir/apply_cuts.py" \
+    --crf "$CRF" --preset "$PRESET" --review-md "$review_md" \
+    "$abs_input" "$final_srt" "$cuts_json" "$cut_video" "$cut_srt"
+  burn_video="$cut_video"
+  burn_srt="$cut_srt"
+else
+  echo "[7/8] no cuts to apply, using original video + SRT for burn-in"
+  burn_video="$abs_input"
+  burn_srt="$final_srt"
+fi
+
+if [[ "$BURN" -eq 0 ]]; then
+  echo "[8/8] --no-burn specified, skipping burn-in"
+  echo
+  echo "outputs:"
+  echo "  srt:   $final_srt"
+  [[ "$CUT" -eq 1 ]] && echo "  cuts: $cuts_json"
+  [[ -f "$review_md" ]] && echo "  review: $review_md"
+  [[ -f "$cut_srt" ]] && echo "  cut srt: $cut_srt"
+  [[ -f "$proofread_diff" ]] && echo "  diff:  $proofread_diff"
+  exit 0
+fi
+
+# ────────────────── [8] burn-in ──────────────────
+if [[ "$FONTSIZE" -eq 0 ]]; then
+  vheight=$(ffprobe -v error -select_streams v:0 \
+    -show_entries stream=height -of default=nw=1:nk=1 "$burn_video" 2>/dev/null || echo 1080)
+  FONTSIZE=$(python3 -c "print(max(24, round(${vheight:-1080} * 0.04)))")
+fi
+margin_v=$(( FONTSIZE ))
+
+echo "[8/8] burning subtitles -> $out_mp4 (font=$FONT size=$FONTSIZE crf=$CRF preset=$PRESET)"
+escaped_srt="$(printf '%s' "$burn_srt" | sed -e 's/:/\\:/g' -e "s/'/\\\\'/g")"
+ffmpeg -y -loglevel error \
+  -i "$burn_video" \
+  -vf "subtitles='$escaped_srt':force_style='FontName=$FONT,FontSize=$FONTSIZE,Outline=3,Shadow=0,BorderStyle=1,PrimaryColour=&H00FFFFFF,OutlineColour=&H00000000,MarginV=$margin_v,WrapStyle=2'" \
+  -c:v libx264 -crf "$CRF" -preset "$PRESET" -pix_fmt yuv420p \
+  -c:a copy \
+  -movflags +faststart \
+  "$out_mp4"
+
+echo
+echo "done."
+echo "outputs:"
+echo "  srt:           $final_srt"
+[[ -f "$proofread_diff" ]] && echo "  proofread diff: $proofread_diff"
+[[ -f "$cuts_json" ]] && echo "  cuts:          $cuts_json"
+[[ -f "$review_md" ]] && echo "  review:        $review_md"
+[[ -f "$cut_video" ]] && echo "  cut video:     $cut_video"
+[[ -f "$cut_srt" ]] && echo "  cut srt:       $cut_srt"
+echo "  burned-in:     $out_mp4"

--- a/scripts/video-subtitle/tests/test_apply_cuts.py
+++ b/scripts/video-subtitle/tests/test_apply_cuts.py
@@ -1,0 +1,107 @@
+"""Tests for apply_cuts.py — SRT timestamp shifting and keep-range math.
+
+The ffmpeg side is exercised in integration; here we just verify the
+deterministic logic that gets edits right or wrong.
+"""
+from __future__ import annotations
+
+import pathlib
+import sys
+import unittest
+
+HERE = pathlib.Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE.parent))
+
+import apply_cuts as ac  # noqa: E402
+import clean_srt as cs   # noqa: E402
+
+
+class KeepRangesTest(unittest.TestCase):
+    def test_no_cuts(self):
+        self.assertEqual(ac.keep_ranges([], 10.0), [(0.0, 10.0)])
+
+    def test_single_cut_in_middle(self):
+        cuts = [{"start": 3.0, "end": 5.0}]
+        self.assertEqual(ac.keep_ranges(cuts, 10.0), [(0.0, 3.0), (5.0, 10.0)])
+
+    def test_cut_at_start(self):
+        cuts = [{"start": 0.0, "end": 2.0}]
+        self.assertEqual(ac.keep_ranges(cuts, 10.0), [(2.0, 10.0)])
+
+    def test_cut_at_end(self):
+        cuts = [{"start": 8.0, "end": 10.0}]
+        self.assertEqual(ac.keep_ranges(cuts, 10.0), [(0.0, 8.0)])
+
+    def test_overlapping_cuts_collapsed(self):
+        cuts = [{"start": 1.0, "end": 4.0}, {"start": 3.0, "end": 6.0}]
+        self.assertEqual(ac.keep_ranges(cuts, 10.0), [(0.0, 1.0), (6.0, 10.0)])
+
+    def test_adjacent_cuts(self):
+        cuts = [{"start": 1.0, "end": 2.0}, {"start": 2.0, "end": 3.0}]
+        self.assertEqual(ac.keep_ranges(cuts, 10.0), [(0.0, 1.0), (3.0, 10.0)])
+
+
+class SrtShiftTest(unittest.TestCase):
+    def _cue(self, start: float, end: float, text: str = "x") -> cs.Cue:
+        return cs.Cue(0, start, end, text)
+
+    def test_cue_entirely_inside_cut_dropped(self):
+        cues = [self._cue(3.0, 4.0, "dropped")]
+        keeps = [(0.0, 2.0), (5.0, 10.0)]
+        out = ac.shift_srt(cues, keeps)
+        self.assertEqual(out, [])
+
+    def test_cue_in_first_segment_preserved(self):
+        cues = [self._cue(0.0, 1.5, "kept")]
+        keeps = [(0.0, 2.0), (5.0, 10.0)]
+        out = ac.shift_srt(cues, keeps)
+        self.assertEqual(len(out), 1)
+        self.assertAlmostEqual(out[0].start, 0.0)
+        self.assertAlmostEqual(out[0].end, 1.5)
+        self.assertEqual(out[0].text, "kept")
+
+    def test_cue_in_second_segment_shifted_by_cut_duration(self):
+        # Cut is 3s long (2->5). A cue at 6.0->7.0 in original time should
+        # land at 3.0->4.0 in cut time.
+        cues = [self._cue(6.0, 7.0, "shifted")]
+        keeps = [(0.0, 2.0), (5.0, 10.0)]
+        out = ac.shift_srt(cues, keeps)
+        self.assertEqual(len(out), 1)
+        self.assertAlmostEqual(out[0].start, 3.0)
+        self.assertAlmostEqual(out[0].end, 4.0)
+
+    def test_cue_straddling_cut_keeps_majority_side(self):
+        # Cue 1.5->5.5; cut is 2->5. Pre-cut overlap = 0.5s, post-cut = 0.5s.
+        # Majority isn't strictly larger; either side is acceptable as long
+        # as the cue is preserved (not dropped) and timestamps map cleanly.
+        cues = [self._cue(1.5, 5.5, "straddle")]
+        keeps = [(0.0, 2.0), (5.0, 10.0)]
+        out = ac.shift_srt(cues, keeps)
+        self.assertEqual(len(out), 1)
+        # Whichever side wins, mapped time must lie inside the cut timeline
+        # (total duration = 7s after removing 3s).
+        self.assertGreaterEqual(out[0].start, 0.0)
+        self.assertLessEqual(out[0].end, 7.0)
+        self.assertLess(out[0].start, out[0].end)
+
+    def test_multiple_cues_renumbered(self):
+        cues = [
+            self._cue(0.0, 1.0, "a"),
+            self._cue(3.0, 4.0, "dropped"),  # inside cut
+            self._cue(6.0, 7.0, "b"),
+            self._cue(8.0, 9.0, "c"),
+        ]
+        keeps = [(0.0, 2.0), (5.0, 10.0)]
+        out = cs.reindex(ac.shift_srt(cues, keeps))
+        self.assertEqual(len(out), 3)
+        self.assertEqual([c.text for c in out], ["a", "b", "c"])
+        self.assertEqual([c.index for c in out], [1, 2, 3])
+
+    def test_no_cuts_passes_through(self):
+        cues = [self._cue(0.0, 1.0, "a"), self._cue(2.0, 3.0, "b")]
+        out = ac.shift_srt(cues, [(0.0, 5.0)])
+        self.assertEqual(len(out), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/video-subtitle/tests/test_clean_srt.py
+++ b/scripts/video-subtitle/tests/test_clean_srt.py
@@ -1,0 +1,181 @@
+"""Tests for clean_srt.py. Stdlib-only; run with `python3 -m unittest`."""
+from __future__ import annotations
+
+import pathlib
+import sys
+import unittest
+
+HERE = pathlib.Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE.parent))
+
+import clean_srt as m  # noqa: E402
+
+
+def pipeline(src: str, lang: str = "ja") -> list[m.Cue]:
+    cues = m.parse_srt(src)
+    cues = [m.Cue(c.index, c.start, c.end, m.normalise_text(c.text)) for c in cues]
+    cues = m.collapse_loops_in_cues(cues)
+    cues = m.strip_hallucinations(cues, lang)
+    cues = m.dedupe_consecutive(cues)
+    cues = m.merge_too_short(cues)
+    cues = m.split_too_long(cues)
+    return m.reindex(cues)
+
+
+class LoopCollapseTest(unittest.TestCase):
+    def test_collapses_japanese_decoder_loop(self):
+        text = "ありがとうございました" * 5
+        self.assertEqual(m.collapse_repetition_loops(text), "ありがとうございました")
+
+    def test_collapses_english_loop(self):
+        self.assertEqual(m.collapse_repetition_loops("hello hello hello hello"),
+                         "hello")
+
+    def test_keeps_double_repetition_intact(self):
+        # "とても とても" is idiomatic emphasis — only >=3 reps collapse.
+        self.assertEqual(m.collapse_repetition_loops("とても とても"), "とても とても")
+
+    def test_collapses_with_punctuation_between(self):
+        text = "ありがとう、ありがとう、ありがとう、ありがとう"
+        self.assertEqual(m.collapse_repetition_loops(text), "ありがとう")
+
+    def test_drops_cue_if_collapse_leaves_empty(self):
+        src = "1\n00:00:00,000 --> 00:00:05,000\n \n"
+        cues = m.collapse_loops_in_cues(m.parse_srt(src))
+        self.assertEqual(len(cues), 0)
+
+
+class ExpandedHallucinationTest(unittest.TestCase):
+    def test_strips_gosechou(self):
+        src = ("1\n00:00:00,000 --> 00:00:02,000\n本編\n\n"
+               "2\n00:00:02,000 --> 00:00:04,000\nご清聴ありがとうございました\n")
+        cues = pipeline(src, "ja")
+        self.assertEqual(len(cues), 1)
+        self.assertEqual(cues[0].text, "本編")
+
+    def test_strips_subscribe_variants(self):
+        for tail in ("like and subscribe",
+                     "Please subscribe to the channel",
+                     "Don't forget to like"):
+            src = (f"1\n00:00:00,000 --> 00:00:02,000\nreal\n\n"
+                   f"2\n00:00:02,000 --> 00:00:04,000\n{tail}\n")
+            cues = pipeline(src, "en")
+            self.assertEqual(len(cues), 1, f"failed on {tail!r}")
+            self.assertEqual(cues[0].text, "real")
+
+
+class ParseTest(unittest.TestCase):
+    def test_basic(self):
+        src = "1\n00:00:01,000 --> 00:00:02,000\nhello\n"
+        cues = m.parse_srt(src)
+        self.assertEqual(len(cues), 1)
+        self.assertEqual(cues[0].text, "hello")
+        self.assertAlmostEqual(cues[0].start, 1.0)
+        self.assertAlmostEqual(cues[0].end, 2.0)
+
+    def test_missing_index_line(self):
+        src = "00:00:01,000 --> 00:00:02,000\nhello\n"
+        cues = m.parse_srt(src)
+        self.assertEqual(len(cues), 1)
+        self.assertEqual(cues[0].text, "hello")
+
+    def test_crlf_and_bom(self):
+        src = "\ufeff1\r\n00:00:01,000 --> 00:00:02,000\r\nhi\r\n"
+        cues = m.parse_srt(src)
+        self.assertEqual(len(cues), 1)
+        self.assertEqual(cues[0].text, "hi")
+
+
+class TimeFormatTest(unittest.TestCase):
+    def test_roundtrip(self):
+        self.assertEqual(m.fmt_time(0), "00:00:00,000")
+        self.assertEqual(m.fmt_time(3661.25), "01:01:01,250")
+
+    def test_ms_rounding_carry(self):
+        # 0.9995 would naively format as ",1000" — must carry.
+        self.assertEqual(m.fmt_time(0.9995), "00:00:01,000")
+
+
+class HallucinationTest(unittest.TestCase):
+    def test_strips_trailing_ja_hallucination(self):
+        src = (
+            "1\n00:00:00,000 --> 00:00:02,000\n本編です\n\n"
+            "2\n00:00:02,000 --> 00:00:04,000\nご視聴ありがとうございました\n"
+        )
+        cues = pipeline(src, "ja")
+        self.assertEqual(len(cues), 1)
+        self.assertEqual(cues[0].text, "本編です")
+
+    def test_strips_en_thanks_for_watching(self):
+        src = (
+            "1\n00:00:00,000 --> 00:00:02,000\nreal content\n\n"
+            "2\n00:00:02,000 --> 00:00:04,000\nThanks for watching.\n"
+        )
+        cues = pipeline(src, "en")
+        self.assertEqual(len(cues), 1)
+        self.assertEqual(cues[0].text, "real content")
+
+
+class DedupeTest(unittest.TestCase):
+    def test_merges_consecutive_duplicates(self):
+        src = (
+            "1\n00:00:00,000 --> 00:00:01,000\nhello\n\n"
+            "2\n00:00:01,000 --> 00:00:02,000\nhello\n"
+        )
+        cues = pipeline(src, "en")
+        self.assertEqual(len(cues), 1)
+        self.assertAlmostEqual(cues[0].start, 0.0)
+        self.assertAlmostEqual(cues[0].end, 2.0)
+
+
+class MergeShortTest(unittest.TestCase):
+    def test_orphan_leading_short_cue_merges_forward(self):
+        src = (
+            "1\n00:00:00,000 --> 00:00:00,200\nあ\n\n"
+            "2\n00:00:00,200 --> 00:00:02,000\n本編\n"
+        )
+        cues = pipeline(src, "ja")
+        self.assertEqual(len(cues), 1)
+        self.assertIn("あ", cues[0].text)
+        self.assertIn("本編", cues[0].text)
+
+    def test_trailing_short_cue_merges_backward(self):
+        src = (
+            "1\n00:00:00,000 --> 00:00:02,000\n本編\n\n"
+            "2\n00:00:02,000 --> 00:00:02,200\nあ\n"
+        )
+        cues = pipeline(src, "ja")
+        self.assertEqual(len(cues), 1)
+        self.assertAlmostEqual(cues[0].end, 2.2)
+
+
+class SplitLongTest(unittest.TestCase):
+    def test_splits_on_japanese_period(self):
+        # Must exceed MAX_CHARS (42) so split_too_long actually activates.
+        text = (
+            "一文目はそれなりに長い文章で読点も含みます。"
+            "二文目も同じくらい長めにしておきますね。"
+            "三文目もついでに長めの文章にしておきます。"
+        )
+        assert len(text) > m.MAX_CHARS, "fixture must exceed MAX_CHARS"
+        src = f"1\n00:00:00,000 --> 00:00:09,000\n{text}\n"
+        cues = pipeline(src, "ja")
+        self.assertEqual(len(cues), 3)
+        self.assertAlmostEqual(cues[-1].end, 9.0, places=3)
+        for c in cues:
+            self.assertLess(c.start, c.end)
+
+    def test_keeps_short_cues_intact(self):
+        src = "1\n00:00:00,000 --> 00:00:02,000\n短い行\n"
+        cues = pipeline(src, "ja")
+        self.assertEqual(len(cues), 1)
+        self.assertEqual(cues[0].text, "短い行")
+
+
+class NormaliseTest(unittest.TestCase):
+    def test_full_width_space_collapsed(self):
+        self.assertEqual(m.normalise_text("あ\u3000 い"), "あ  い".replace("  ", " "))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/video-subtitle/tests/test_detect_fillers.py
+++ b/scripts/video-subtitle/tests/test_detect_fillers.py
@@ -1,0 +1,114 @@
+"""Tests for detect_fillers.py. Stdlib-only; run with `python3 -m unittest`."""
+from __future__ import annotations
+
+import pathlib
+import sys
+import unittest
+
+HERE = pathlib.Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE.parent))
+
+import detect_fillers as df  # noqa: E402
+
+
+def w(start: float, end: float, word: str, prob: float = 0.9) -> dict:
+    return {"start": start, "end": end, "word": word, "probability": prob}
+
+
+class FillerTest(unittest.TestCase):
+    def test_picks_up_basic_japanese_filler(self):
+        words = [w(0.0, 0.3, "えー"), w(0.4, 1.0, "始めます")]
+        cuts = df.detect(words, dictionary=df.CONSERVATIVE_FILLERS)
+        self.assertEqual(len(cuts), 1)
+        self.assertEqual(cuts[0].reason, "filler")
+        self.assertEqual(cuts[0].text, "えー")
+
+    def test_does_not_cut_meaningful_word_in_conservative_mode(self):
+        # "あの" is meaningful ("that"), so the conservative dictionary leaves it alone.
+        words = [w(0.0, 0.4, "あの"), w(0.5, 1.0, "人")]
+        cuts = df.detect(words, dictionary=df.CONSERVATIVE_FILLERS)
+        self.assertEqual(cuts, [])
+
+    def test_aggressive_mode_does_cut_ano(self):
+        words = [w(0.0, 0.4, "あの"), w(0.5, 1.0, "人")]
+        cuts = df.detect(words, dictionary=df.AGGRESSIVE_FILLERS)
+        self.assertEqual(len(cuts), 1)
+        self.assertEqual(cuts[0].text, "あの")
+
+    def test_normalises_long_vowel_variants(self):
+        words = [w(0.0, 0.4, "えーっと"), w(0.5, 1.0, "次")]
+        cuts = df.detect(words, dictionary=df.CONSERVATIVE_FILLERS)
+        self.assertEqual(len(cuts), 1)
+
+
+class StutterTest(unittest.TestCase):
+    def test_collapses_three_consecutive_repeats(self):
+        # "あの あの あの 始めます" — drop the first two, keep last + content.
+        words = [
+            w(0.0, 0.3, "あの"),
+            w(0.4, 0.7, "あの"),
+            w(0.8, 1.1, "あの"),
+            w(1.2, 2.0, "始めます"),
+        ]
+        cuts = df.detect(words, dictionary=set(), detect_stutters=True)
+        # Cuts cover the first two "あの" but not the last one or the content.
+        self.assertEqual(len(cuts), 2)
+        self.assertTrue(all(c.reason == "stutter" for c in cuts))
+        for c in cuts:
+            self.assertLess(c.end, words[2]["start"])  # all before the kept "あの"
+
+    def test_two_repeats_left_alone(self):
+        # Threshold is 3; two reps is normal emphasis.
+        words = [w(0.0, 0.3, "あの"), w(0.4, 0.7, "あの"), w(0.8, 1.5, "始めます")]
+        cuts = df.detect(words, dictionary=set(), detect_stutters=True)
+        self.assertEqual(cuts, [])
+
+    def test_repeats_separated_by_long_gap_not_a_stutter(self):
+        words = [w(0.0, 0.3, "あの"), w(2.0, 2.3, "あの"), w(2.4, 3.0, "あの")]
+        cuts = df.detect(words, dictionary=set(), detect_stutters=True)
+        # First "あの" gap to second is > STUTTER_GAP, so the run resets.
+        # Only second+third are within window — that's 2, not 3 → no cut.
+        self.assertEqual(cuts, [])
+
+
+class SilenceTest(unittest.TestCase):
+    def test_long_silence_trimmed_when_threshold_set(self):
+        words = [w(0.0, 1.0, "始めます"), w(5.0, 6.0, "次")]
+        cuts = df.detect(words, dictionary=set(), silence_threshold=2.0)
+        self.assertEqual(len(cuts), 1)
+        self.assertEqual(cuts[0].reason, "long_silence")
+        # We trim down to LONG_SILENCE_KEEP (~0.3s); cut should be ~3.7s long.
+        self.assertAlmostEqual(cuts[0].end - cuts[0].start, 4.0 - 0.3, places=2)
+
+    def test_silence_below_threshold_left_alone(self):
+        words = [w(0.0, 1.0, "始めます"), w(2.0, 3.0, "次")]
+        cuts = df.detect(words, dictionary=set(), silence_threshold=2.0)
+        self.assertEqual(cuts, [])
+
+    def test_silence_off_by_default(self):
+        words = [w(0.0, 1.0, "始めます"), w(10.0, 11.0, "次")]
+        cuts = df.detect(words, dictionary=set())
+        self.assertEqual(cuts, [])
+
+
+class ExcludesTest(unittest.TestCase):
+    def test_exclude_protects_a_range(self):
+        words = [w(0.0, 0.3, "えー"), w(2.0, 2.3, "えー")]
+        cuts = df.detect(words, dictionary=df.CONSERVATIVE_FILLERS)
+        self.assertEqual(len(cuts), 2)
+        cuts = df.apply_excludes(cuts, [(0.0, 1.0)])
+        self.assertEqual(len(cuts), 1)
+        self.assertGreater(cuts[0].start, 1.0)
+
+
+class MergeOverlapTest(unittest.TestCase):
+    def test_overlapping_cuts_merge(self):
+        words = [w(0.0, 0.3, "えー"), w(0.31, 0.5, "えーと")]
+        cuts = df.detect(words, dictionary=df.CONSERVATIVE_FILLERS)
+        # Both cuts overlap due to padding — should collapse to one.
+        self.assertEqual(len(cuts), 1)
+        self.assertGreater(cuts[0].end - cuts[0].start, 0.4)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/video-subtitle/transcribe.py
+++ b/scripts/video-subtitle/transcribe.py
@@ -1,0 +1,161 @@
+"""Transcribe audio with faster-whisper (quality-first) and emit a raw SRT.
+
+Defaults:
+  - Full precision (float32 on CPU, float16 on CUDA). No int8 quantisation
+    so nothing is given up at the encoder level.
+  - beam_size=10 for better search (Whisper's own paper uses 5; we go higher
+    because we cache the result anyway — accuracy wins twice).
+  - condition_on_previous_text=True (Whisper's default). Keeps long-form
+    coherence. Loop hallucinations are caught by clean_srt's loop collapser.
+  - word_timestamps=True enables pause-aware re-segmentation: a long
+    Whisper chunk is split at >=PAUSE_THRESHOLD silence between words so the
+    output SRT breaks at natural speech boundaries, not arbitrary 30s
+    offsets.
+  - Silero VAD on (can disable with --no-vad).
+
+Invoked as:
+    python3 transcribe.py --lang ja --model large-v3 in.wav out.raw.srt
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+
+HERE = pathlib.Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+
+import clean_srt  # noqa: E402
+
+
+PAUSE_THRESHOLD = 0.6  # seconds of silence between words that triggers a cue break
+MAX_CUE_DURATION = 6.0  # seconds; segments longer than this are re-split by pause
+
+
+def _process_segments(segments):
+    """Collect cues (re-segmented at natural pauses) and word-level timing.
+
+    Returns (cues, words). ``words`` is a flat list of ``{start, end, word,
+    probability}`` dicts suitable for json.dump — used downstream by
+    detect_fillers.py.
+    """
+    cues: list[clean_srt.Cue] = []
+    words_out: list[dict] = []
+    for seg in segments:
+        seg_text = (seg.text or "").strip()
+        if not seg_text:
+            continue
+        words = [w for w in (seg.words or []) if (w.word or "").strip()]
+        for w in words:
+            words_out.append({
+                "start": float(w.start),
+                "end": float(w.end),
+                "word": (w.word or "").strip(),
+                "probability": float(getattr(w, "probability", 0.0) or 0.0),
+            })
+        if not words or (seg.end - seg.start) <= MAX_CUE_DURATION:
+            cues.append(clean_srt.Cue(
+                len(cues) + 1, float(seg.start), float(seg.end), seg_text))
+            continue
+
+        # Group consecutive words, starting a new cue after a long pause or
+        # once the current cue would exceed MAX_CUE_DURATION.
+        group_start = float(words[0].start)
+        group_words: list[str] = []
+        last_end = group_start
+        for w in words:
+            pause = float(w.start) - last_end
+            group_dur = float(w.end) - group_start
+            if group_words and (pause >= PAUSE_THRESHOLD or group_dur >= MAX_CUE_DURATION):
+                cues.append(clean_srt.Cue(
+                    len(cues) + 1, group_start, last_end,
+                    "".join(group_words).strip()))
+                group_start = float(w.start)
+                group_words = []
+            group_words.append(w.word or "")
+            last_end = float(w.end)
+        if group_words:
+            cues.append(clean_srt.Cue(
+                len(cues) + 1, group_start, last_end,
+                "".join(group_words).strip()))
+    return cues, words_out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("src")
+    ap.add_argument("dst")
+    ap.add_argument("--lang", default="ja")
+    ap.add_argument("--model", default="large-v3",
+                    help="tiny|base|small|medium|large-v3 or HF repo id "
+                         "(default large-v3 for best accuracy)")
+    ap.add_argument("--device", default="auto",
+                    help="auto|cpu|cuda")
+    ap.add_argument("--beam-size", type=int, default=10,
+                    help="higher = more thorough search, slower (default 10)")
+    ap.add_argument("--no-vad", action="store_true",
+                    help="Disable Silero VAD (use when audio is already tight)")
+    ap.add_argument("--prompt", default="",
+                    help="initial_prompt — nudges vocabulary toward given terms")
+    ap.add_argument("--words-json", default="",
+                    help="If set, also write the per-word timing list to this path "
+                         "(consumed by detect_fillers.py)")
+    args = ap.parse_args()
+
+    try:
+        from faster_whisper import WhisperModel
+    except ImportError:
+        print("faster-whisper not installed; run scripts/video-subtitle/bootstrap.sh",
+              file=sys.stderr)
+        return 127
+
+    device = args.device
+    # Quality-first compute types. Never int8.
+    if device == "auto":
+        try:
+            import torch  # type: ignore
+            device = "cuda" if torch.cuda.is_available() else "cpu"
+        except ImportError:
+            device = "cpu"
+    compute_type = "float16" if device == "cuda" else "float32"
+
+    print(f"transcribe: model={args.model} device={device} compute={compute_type} "
+          f"lang={args.lang} beam={args.beam_size}", file=sys.stderr)
+    model = WhisperModel(args.model, device=device, compute_type=compute_type)
+
+    transcribe_kwargs = dict(
+        language=args.lang,
+        beam_size=args.beam_size,
+        vad_filter=not args.no_vad,
+        vad_parameters=dict(min_silence_duration_ms=500),
+        # Whisper's own coherence-preserving default. Loops are post-cleaned.
+        condition_on_previous_text=True,
+        # Built-in temperature fallback lets the decoder escape bad runs.
+        temperature=[0.0, 0.2, 0.4, 0.6, 0.8, 1.0],
+        compression_ratio_threshold=2.4,
+        log_prob_threshold=-1.0,
+        no_speech_threshold=0.6,
+        word_timestamps=True,
+    )
+    if args.prompt:
+        transcribe_kwargs["initial_prompt"] = args.prompt
+
+    segments, info = model.transcribe(args.src, **transcribe_kwargs)
+    cues, words = _process_segments(segments)
+
+    with open(args.dst, "w", encoding="utf-8") as f:
+        f.write(clean_srt.emit(cues))
+
+    if args.words_json:
+        with open(args.words_json, "w", encoding="utf-8") as f:
+            json.dump(words, f, ensure_ascii=False, indent=2)
+
+    dur = info.duration if info else 0.0
+    print(f"transcribe: wrote {len(cues)} cues, {len(words)} words "
+          f"covering ~{dur:.1f}s of audio", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
動画の字幕生成〜焼き込みまでを **1コマンド** で完結させるパイプラインを追加します。従来の Premiere 運用（文字起こし → Filler Word Detection → SRT書き出し → Claude校正 → 戻し）を全置換。

```
入力動画
  └─ ffmpeg: 抽出 (highpass 80Hz)
       └─ ffmpeg: 2-pass loudnorm (-16 LUFS, linear)  [放送基準]
            └─ faster-whisper large-v3 (float32, beam 10, word timestamps,
               glossary を initial_prompt に注入)
                 └─ clean_srt.py: Whisper loop/幻覚 除去
                      └─ proofread.py: Claude Sonnet 4.6 で校正 (glossary キャッシュ)
                          └─ detect_fillers.py: word timestamps からフィラー/吃り/長無音検出
                              └─ apply_cuts.py: ffmpeg で該当区間カット (音声フェード)
                                  └─ ffmpeg: CRF 17 / preset slow で焼き込み
```

`/video-subtitle` スラッシュコマンドとしても呼べます。

## 追加ファイル
- `.claude/skills/video-subtitle/SKILL.md`
- `scripts/video-subtitle/run.sh`（一発実行ドライバ）
- `scripts/video-subtitle/bootstrap.sh`（ffmpeg + python依存インストール）
- `scripts/video-subtitle/{transcribe,clean_srt,proofread,detect_fillers,apply_cuts}.py`
- `scripts/video-subtitle/glossary.txt`
- `scripts/video-subtitle/tests/test_*.py`

## 実行
```bash
scripts/video-subtitle/run.sh path/to/input.mp4
```

## 有効化に必要な設定
- ローカル or CI環境に `ffmpeg`、Python 3.10+
- `scripts/video-subtitle/bootstrap.sh` が依存を入れます
- `ANTHROPIC_API_KEY` 環境変数（proofread.py のClaude校正用）

## 品質ポリシー
静かに品質とスピードをトレードオフしない設計。フィラーカット区間は `cuts.json` に書き出され、目視確認後に `--exclude-cut` で個別除外可能。

## Test plan
- [ ] `pytest scripts/video-subtitle/tests/` でユニットテスト通過
- [ ] 短いサンプル動画で `run.sh` 一発実行が完走
- [ ] カット除外を `--exclude-cut 3,5` で指定すると該当区間がカットされない

## 関連PR
- PR #1: nightly
- PR #2: uptime-monitor
- PR #3: ai-news

https://claude.ai/code/session_01TBRDmevYeQxvBBbwrNmPfi