### PR TITLE
fix(diag): suppress on-screen error overlay in production

### DIFF
--- a/index.html
+++ b/index.html
@@ -174,9 +174,14 @@
         } catch (e) {}
       }
 
-      // On-screen error diagnostic — show JS errors directly in the boot-splash
+      // Error diagnostic — log to console always; show on-screen only when ?debug=1.
+      // (The on-screen overlay was catching benign third-party rejections, e.g. LINE
+      // in-app browser's LIFF bridge, and flashing them to end-users.)
       (function() {
-        function showError(msg, src) {
+        var showOverlay = /[?&]debug=1\b/.test(location.search);
+        function report(msg, src) {
+          try { console.error('[diag]', msg, src || ''); } catch (_) {}
+          if (!showOverlay) return;
           var el = document.getElementById('boot-splash-error');
           if (!el) {
             el = document.createElement('div');
@@ -187,17 +192,19 @@
           el.textContent += '[' + new Date().toLocaleTimeString() + '] ' + msg + (src ? ' @ ' + src : '') + '\n';
         }
         window.addEventListener('error', function(e) {
-          showError(e.message || 'unknown error', e.filename ? (e.filename + ':' + e.lineno) : '');
+          report(e.message || 'unknown error', e.filename ? (e.filename + ':' + e.lineno) : '');
         });
         window.addEventListener('unhandledrejection', function(e) {
           var r = e.reason;
-          showError('UnhandledRejection: ' + (r && (r.message || r.toString()) || 'unknown'));
+          report('UnhandledRejection: ' + (r && (r.message || r.toString()) || 'unknown'));
         });
-        // If after 6s #root still has the boot-splash, React never mounted.
+        // If after 6s #root still has the boot-splash, React never mounted — always surface this one.
         setTimeout(function() {
           var root = document.getElementById('root');
           if (root && root.querySelector('#boot-splash')) {
-            showError('React did not mount within 6s. Bundle may have failed to execute.');
+            var prev = showOverlay; showOverlay = true;
+            report('React did not mount within 6s. Bundle may have failed to execute.');
+            showOverlay = prev;
           }
         }, 6000);
       })();


### PR DESCRIPTION
## Summary
iPhone / LINE内ブラウザで lumenium.net を開くと、画面下部に赤い帯でエラーが表示される問題を修正します。

**スクリーンショット例（報告時刻 9:05 JST）：**
```
[9:05:36] UnhandledRejection: undefined is not an object
          (evaluating 'response.msg')
```

## 原因

`index.html` にあった **開発用のオンスクリーンエラーオーバーレイ** が `window.unhandledrejection` をすべて捕獲し、赤い帯で表示していました。元は「boot-splash が出ない問題を調査するため」に追加されたデバッグコードで、本番には残すべきではないものです。

今回表示されていた `response.msg` というエラー文字列は **Lumenium 側のソースコードには存在しません**（`src/` 全体を grep 済み）。文字列の形式（`undefined is not an object`）は iOS Safari / LINE内ブラウザ特有。**LINEアプリが注入する LIFF / ブリッジ系スクリプト** が非同期コールバックで `response.msg` を参照して失敗した時のレポートを、我々のオーバーレイが拾って表示していたと考えられます。

ユーザーが9:10に見たときには消えていたという証言は、LINEブリッジのタイミング依存であり、自社サイト側のバグではないことの傍証です。

## 直近のルーチン導入との関係

結論：**無関係**。
- nightly workflow は secret未登録のため**まだ一度も実行されていない**
- PR #1 のうち本番に配信されたのは `public/` の画像・動画圧縮のみで、JS挙動には無影響
- この赤バナーは以前から index.html に仕込まれていたデバッグ装置で、条件が揃えば以前から表示されていた

## 修正内容

`index.html` の診断ブロックを次のように変更：

| 挙動 | Before | After |
|---|---|---|
| オンスクリーン赤バナー | **常時表示** | `?debug=1` のときだけ表示 |
| `console.error` ロギング | ✗ | ✅ 常時 |
| 「React did not mount within 6s」表示 | 常時 | 常時（本当の致命エラーなので維持） |

## 使い方
- `https://lumenium.net/` — 本番、赤バナー出ない
- `https://lumenium.net/?debug=1` — 開発時、エラーが出たら赤バナー表示

## Test plan
- [ ] マージ後、Vercel 自動デプロイ完了
- [ ] iPhone / LINE内ブラウザで lumenium.net を開き、赤バナーが出ないことを確認
- [ ] `https://lumenium.net/?debug=1` で従来通り赤バナーが出ることを確認
- [ ] Safari/Chrome のDevTools Console に `[diag]` から始まる error ログが出ることを確認（捕獲は継続）

https://claude.ai/code/session_01TBRDmevYeQxvBBbwrNmPfi