### PR TITLE
fix(cache): disable HTML caching to stop stale copy serving

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -28,6 +28,18 @@
       ]
     },
     {
+      "source": "/(index\\.html)?",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=0, s-maxage=0, must-revalidate" }
+      ]
+    },
+    {
+      "source": "/(404|game|racing|runner|specified-commerce)\\.html",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=0, s-maxage=0, must-revalidate" }
+      ]
+    },
+    {
       "source": "/intro.mp4",
       "headers": [
         { "key": "Cache-Control", "value": "public, max-age=604800" }


### PR DESCRIPTION
## 背景
PR #7, #9, #10 がマージ済みなのに、lumenium.net で古い内容（「納期目安 2週間〜」「教材 別途」「フリーランスとして独立」）が表示され続けているとのご報告。

## 原因仮説
`vercel.json` で `/index.html` および `/*.html` に **明示的な `Cache-Control` ヘッダが無かった** ため、Vercel のエッジCDN・中継キャッシュ（LINE内ブラウザ含む）が古いHTMLを配り続けている可能性。

## 修正
HTML（SPAエントリ + 独立HTMLページ）にキャッシュ無効化ヘッダを付与：

```
Cache-Control: public, max-age=0, s-maxage=0, must-revalidate
```

- `/`（index.html）
- `/404.html`, `/game.html`, `/racing.html`, `/runner.html`, `/specified-commerce.html`

ハッシュ付き `/assets/*`（JS/CSS）は従来通り1年 immutable のまま。

## 副次効果
この PR をマージすると Vercel に **強制的に新しいデプロイがトリガー**されるため、もし直前の Vercel デプロイが失敗していた場合でも、これを機にキューが復活します。

## Test plan
- [ ] マージ後、Vercel ダッシュボードで `13f8743` のデプロイが成功
- [ ] https://lumenium.net/ を開き、納期目安が消えている
- [ ] AI導入・研修の表記が `10万円〜（教材費込）/ 交通費別途` になっている
- [ ] About セクションが「個人事業主として活動開始」になっている
- [ ] レスポンスヘッダに `cache-control: public, max-age=0, ...` が付いている（`curl -I https://lumenium.net/` で確認可能）

https://claude.ai/code/session_01TBRDmevYeQxvBBbwrNmPfi