### PR TITLE
copy(profile): remove remaining 独立 in the hero description

### DIFF
--- a/src/components/Profile.jsx
+++ b/src/components/Profile.jsx
@@ -24,7 +24,7 @@ export default function Profile() {
             <p className="profile-role">Lumenium 代表</p>
 
             <div className="profile-desc">
-              <p>慶應義塾大学 文学部 卒業。在学中に独立。</p>
+              <p>慶應義塾大学 文学部 卒業。在学中から個人事業主として活動開始。</p>
               <p>動画、AI、Web、SNSなど幅広く活動。</p>
               <p>企業向けAI研修の講師も歴任。</p>
               <p>企画から納品まで一括でサポートします。</p>


### PR DESCRIPTION
## Summary
PR #10 で見落としていた **3箇所目の「独立」** を修正します。

プロフィール上部のヒーロー短い説明文：
- **Before：** `慶應義塾大学 文学部 卒業。在学中に独立。`
- **After：** `慶應義塾大学 文学部 卒業。在学中から個人事業主として活動開始。`

これで `src/` 配下に「独立」は残っていません（grep 確認済）。

## Test plan
- [ ] 自動デプロイ完了後、About セクション上部の短い説明で新文言を確認
- [ ] タイムライン・BACKGROUND本文と整合取れていること

https://claude.ai/code/session_01TBRDmevYeQxvBBbwrNmPfi