### PR TITLE
feat(ops): notify on scheduled workflow failure via auto-filed issue

### DIFF
--- a/.github/workflows/notify-workflow-failures.yml
+++ b/.github/workflows/notify-workflow-failures.yml
@@ -1,0 +1,94 @@
+name: Workflow Failure Notifier
+
+# Watches scheduled routines and opens a GitHub issue when any of them fail.
+# One issue per workflow per UTC day; additional same-day failures just append
+# a comment. Uses only the default GITHUB_TOKEN — no external secrets required.
+
+on:
+  workflow_run:
+    workflows:
+      - Nightly
+      - Lumenium Uptime Monitor
+    types:
+      - completed
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  notify:
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Open or update failure issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const run = context.payload.workflow_run
+            const wfName = run.name
+            const today = new Date().toISOString().slice(0, 10)
+            const label = 'workflow-failure'
+            const title = `⚠️ ${wfName} failed on ${today}`
+
+            const summary = [
+              `**Workflow:** ${wfName}`,
+              `**Run:** [#${run.run_number} / attempt ${run.run_attempt}](${run.html_url})`,
+              `**Event:** ${run.event}`,
+              `**Commit:** \`${run.head_sha.slice(0, 7)}\` (${run.head_branch})`,
+              `**Started:** ${run.run_started_at}`,
+              `**Conclusion:** ${run.conclusion}`,
+            ].join('\n')
+
+            const existing = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: label,
+              state: 'open',
+              per_page: 100,
+            })
+            const match = existing.find((i) => i.title === title)
+
+            if (match) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: match.number,
+                body: `Another failure:\n\n${summary}`,
+              })
+              core.info(`Appended comment to existing issue #${match.number}`)
+              return
+            }
+
+            // Ensure the label exists (ignore 422 already-exists)
+            try {
+              await github.rest.issues.createLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: label,
+                color: 'd73a4a',
+                description: 'Auto-filed by notify-workflow-failures.yml',
+              })
+            } catch (e) {
+              if (e.status !== 422) throw e
+            }
+
+            const body = [
+              `Scheduled workflow **${wfName}** failed today.`,
+              '',
+              summary,
+              '',
+              'Close this issue once the root cause is fixed. If the workflow fails again today,',
+              'this issue will get a new comment instead of opening a duplicate.',
+              '',
+              '<sub>Filed automatically by `.github/workflows/notify-workflow-failures.yml`.</sub>',
+            ].join('\n')
+
+            const created = await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body,
+              labels: [label],
+            })
+            core.info(`Opened issue #${created.data.number}`)


### PR DESCRIPTION
## Summary
スケジュール実行ワークフロー（Nightly / Uptime Monitor）が失敗した時に、**自動でGitHub Issueを立てる仕組み** を追加します。追加のシークレット不要（`GITHUB_TOKEN`のみ使用）。

## なぜ必要か
- secret 未登録のままでは Nightly は毎朝 5時に、Uptime Monitor は **10分毎** に失敗します
- GitHub Actions の標準メール通知は受け取る相手が不確定かつ見落とされやすい
- 失敗の可視化がないと「1ヶ月後に見たら連続失敗してた」が起きる

## 動作

`workflow_run` イベントで監視：
- 対象：`Nightly`, `Lumenium Uptime Monitor`
- 条件：`conclusion == 'failure'`

失敗を検知したら：
1. 当日の UTC 日付でタイトル生成（例：`⚠️ Lumenium Uptime Monitor failed on 2026-04-20`）
2. 同タイトルのオープンIssueが既にあれば **コメント追記**
3. 無ければ **新規Issue作成**（`workflow-failure` ラベル付き）

これで：
- Uptime Monitor が144回/日失敗しても Issue は1つ + コメント追記のみ（夜間に気付いて1個潰すだけ）
- Nightly が5時に失敗したら翌朝までに Issue が立つ

## 使い方
- 失敗の全容は Actions タブの該当ランログを見る
- Issue は「今日は壊れている」の早期警告として機能
- 解決したらIssueを手動でClose（次回失敗で新しいIssueが立つ）

## Test plan
- [ ] マージ後、Uptime Monitor の次回失敗（〜10分以内）で Issue が自動作成される
- [ ] 更に10分後の失敗で、同じIssueにコメントが追記される（新Issueは立たない）
- [ ] ラベル `workflow-failure` が付いている

## 将来の拡張
secret登録 + ルーチン動作確認後、通知先を Notion/Slack にも振り分ける（別PR）

https://claude.ai/code/session_01TBRDmevYeQxvBBbwrNmPfi