### PR TITLE
ops: disable uptime-monitor schedule to stop failure email flood

### DIFF
--- a/.github/workflows/uptime-monitor.yml
+++ b/.github/workflows/uptime-monitor.yml
@@ -5,8 +5,11 @@ name: Lumenium Uptime Monitor
 #   NOTION_TOKEN            - Notion internal integration token with access to the state/alerts pages
 
 on:
-  schedule:
-    - cron: '*/10 * * * *'
+  # Schedule disabled: the job was failing every 10 minutes and flooding the
+  # repo owner's inbox with GitHub's default "Run failed" emails. Re-enable
+  # by uncommenting once the underlying failure is fixed.
+  # schedule:
+  #   - cron: '*/10 * * * *'
   workflow_dispatch:
 
 concurrency:
@@ -75,4 +78,3 @@ jobs:
             - UP→UP のときは Notion にアラートページを作成しない
             - 状態は必ず毎回更新する
             - 処理は60秒以内に完了する
-


### PR DESCRIPTION
## What
Comment out the `schedule: */10 * * * *` trigger in `.github/workflows/uptime-monitor.yml`. `workflow_dispatch` is kept so the job can still be run on demand.

## Why
The scheduled run has been failing every 10 minutes, and GitHub's default workflow-failure email is flooding the repo owner's Gmail (67+ unread as of filing).

## Follow-up (not in this PR)
- Investigate the root cause of the "All jobs have failed / Failed in 23 seconds / 4 annotations" failure (likely a missing/expired secret: `CLAUDE_CODE_OAUTH_TOKEN` or `NOTION_TOKEN`, or a permission change on the Notion pages).
- Re-enable the cron line once the failure is fixed.